### PR TITLE
Fix: Parameterize resource names

### DIFF
--- a/templates/init-spock-job.yaml
+++ b/templates/init-spock-job.yaml
@@ -12,10 +12,10 @@ spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
-      serviceAccountName: init-spock
+      serviceAccountName: {{ .Values.pgEdge.appName }}-init-spock
       restartPolicy: Never
       containers:
-      - name: init-spock
+      - name: {{ .Values.pgEdge.appName }}-init-spock
         image: python:3.12-slim
         command:
           - /bin/sh
@@ -33,19 +33,19 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         volumeMounts:
-          - name: spock-init-script
+          - name: {{ .Values.pgEdge.appName }}-spock-init-script
             mountPath: /scripts
-          - name: pgedge-config
+          - name: {{ .Values.pgEdge.appName }}-pgedge-config
             mountPath: /config
             readOnly: true
           - name: admin-client-cert
             mountPath: /certificates/admin
             readOnly: true
       volumes:
-        - name: spock-init-script
+        - name: {{ .Values.pgEdge.appName }}-spock-init-script
           configMap:
-            name: spock-init-script
-        - name: pgedge-config
+            name: {{ .Values.pgEdge.appName }}-spock-init-script
+        - name: {{ .Values.pgEdge.appName }}-pgedge-config
           configMap:
             name: {{ printf "%s-config" .Values.pgEdge.appName }}
             items:

--- a/templates/init-spock-rbac.yaml
+++ b/templates/init-spock-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: init-spock
+  name: {{ .Values.pgEdge.appName }}-init-spock
   {{- if $.Values.annotations }}
   annotations:
     {{- $.Values.annotations | toYaml | nindent 4 }}
@@ -11,7 +11,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: init-spock
+  name: {{ .Values.pgEdge.appName }}-init-spock
 rules:
   - apiGroups: ["postgresql.cnpg.io"]
     resources: ["clusters"]
@@ -21,12 +21,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: init-spock
+  name: {{ .Values.pgEdge.appName }}-init-spock
 subjects:
   - kind: ServiceAccount
-    name: init-spock
+    name: {{ .Values.pgEdge.appName }}-init-spock
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: init-spock
+  name: {{ .Values.pgEdge.appName }}-init-spock
 {{- end }}

--- a/templates/init-spock-script-configmap.yaml
+++ b/templates/init-spock-script-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: spock-init-script
+  name: {{ .Values.pgEdge.appName }}-spock-init-script
 data:
   init-spock.py: |-
 {{ .Files.Get "scripts/init-spock.py" | indent 4 }}


### PR DESCRIPTION
Parameterize resource names to avoid collisions when deploying the chart multiple times in the same k8s namespace.  It safely names the following resources by prefixing the value of `pgEdge.appName` from the app values.yaml file:

- service account name
- volume mount name
- role binding name
- config map name
- init script job name

Note: this fix does not ensure there are no certificate collisions. 

Simple manual validation test steps:

```
# install the default "single" helm chart example and wait for it to be healthy
helm install --values examples/configs/single/values.yaml pgedge ./ &
kubectl logs --follow jobs/pgedge-init-spock

# install a second instance in the same namespace, but with `provisionCerts: false`
# this chart is exactly the same as "single", but with the `provisionCerts` override.
helm install --values examples/configs/ryan/values.yaml ryan ./ &
kubectl logs --follow jobs/ryan-init-spock

# Once they are both up and healthy, insert some data in each db cluster and ensure that replication is working as expected.
```