### PR TITLE
test: add HA, multi-cluster, and replication slot E2E tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,7 +117,7 @@ jobs:
         run: make -C test kind-load-image
 
       - name: Integration tests
-        run: make -C test test-integration KUBECONTEXT=kind-pgedge-test INIT_SPOCK_IMAGE=pgedge-helm-utils:dev TIMEOUT=10m
+        run: make -C test test-integration KUBECONTEXT=kind-pgedge-test INIT_SPOCK_IMAGE=pgedge-helm-utils:dev TIMEOUT=15m
 
       - name: Collect debug artifacts on failure
         if: failure()

--- a/test/Makefile
+++ b/test/Makefile
@@ -56,7 +56,7 @@ kind-load-image:
 
 .PHONY: test-integration
 test-integration:
-	cd $(test_dir) && go test -tags integration -v -timeout 20m ./integration/...
+	cd $(test_dir) && go test -tags integration -v -timeout 30m ./integration/...
 
 .PHONY: test-integration-kind
 test-integration-kind: kind-up kind-load-image
@@ -67,11 +67,11 @@ test-integration-kind: kind-up kind-load-image
 
 .PHONY: test-install
 test-install:
-	cd $(test_dir) && go test -tags integration -v -timeout 20m -run "TestDistributedInstall|TestSingleNodeInstall" ./integration/...
+	cd $(test_dir) && go test -tags integration -v -timeout 30m -run "TestDistributedInstall|TestSingleNodeInstall" ./integration/...
 
 .PHONY: test-nodes
 test-nodes:
-	cd $(test_dir) && go test -tags integration -v -timeout 20m -run "TestNodes" ./integration/...
+	cd $(test_dir) && go test -tags integration -v -timeout 30m -run "TestNodes" ./integration/...
 
 # ---- All ----
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -150,6 +150,21 @@ func TestDistributedInstall(t *testing.T) {
 		}
 	})
 
+	t.Run("replication_slots_exist", func(t *testing.T) {
+		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
+			t.Run(pod, func(t *testing.T) {
+				out, err := testKube.ExecSQL(pod,
+					"SELECT count(*) FROM pg_replication_slots rs JOIN spock.subscription sub ON sub.sub_slot_name = rs.slot_name;")
+				if err != nil {
+					t.Fatalf("failed to query replication slots on %s: %v", pod, err)
+				}
+				if strings.TrimSpace(out) != "1" {
+					t.Errorf("pod %s: expected 1 logical replication slot for subscription, got: %s", pod, out)
+				}
+			})
+		}
+	})
+
 	t.Run("data_replicates", func(t *testing.T) {
 		_, err := testKube.ExecSQL("pgedge-n1-1",
 			"CREATE TABLE test_repl (id int PRIMARY KEY, val text);")
@@ -237,6 +252,129 @@ func TestDistributedInstall(t *testing.T) {
 			})
 			if err != nil {
 				t.Error("replication broken after idempotent upgrade")
+			}
+		})
+	})
+}
+
+func TestDistributedHAInstall(t *testing.T) {
+	t.Cleanup(func() { uninstallChart(t) })
+	installChart(t, "distributed-ha-values.yaml")
+
+	clusterNames := []string{"pgedge-n1", "pgedge-n2"}
+
+	t.Run("clusters_healthy", func(t *testing.T) {
+		for _, name := range clusterNames {
+			if err := wait.ForClusterHealthy(testKube, name, timeout); err != nil {
+				t.Errorf("cluster %s not healthy: %v", name, err)
+			}
+		}
+	})
+
+	t.Run("init_spock_job_succeeds", func(t *testing.T) {
+		if err := wait.ForJobComplete(testKube, "pgedge-init-spock", timeout); err != nil {
+			logs, _ := testKube.Logs("job/pgedge-init-spock")
+			t.Fatalf("init-spock job failed: %v\nlogs:\n%s", err, logs)
+		}
+	})
+
+	t.Run("spock_nodes_exist", func(t *testing.T) {
+		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
+			t.Run(pod, func(t *testing.T) {
+				out, err := testKube.ExecSQL(pod, "SELECT node_name FROM spock.node ORDER BY node_name;")
+				if err != nil {
+					t.Fatalf("failed to query spock.node on %s: %v", pod, err)
+				}
+				for _, expected := range []string{"n1", "n2"} {
+					if !strings.Contains(out, expected) {
+						t.Errorf("pod %s: spock.node missing %s, got: %s", pod, expected, out)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("subscriptions_established", func(t *testing.T) {
+		for _, tc := range []struct {
+			pod  string
+			peer string
+		}{
+			{"pgedge-n1-1", "n2"},
+			{"pgedge-n2-1", "n1"},
+		} {
+			t.Run(tc.pod, func(t *testing.T) {
+				out, err := testKube.ExecSQL(tc.pod,
+					"SELECT count(*) FROM spock.subscription;")
+				if err != nil {
+					t.Fatalf("failed to query subscription count on %s: %v", tc.pod, err)
+				}
+				if strings.TrimSpace(out) != "1" {
+					t.Errorf("pod %s: expected 1 subscription, got: %s", tc.pod, out)
+				}
+			})
+		}
+	})
+
+	t.Run("replication_slots_exist", func(t *testing.T) {
+		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
+			t.Run(pod, func(t *testing.T) {
+				out, err := testKube.ExecSQL(pod,
+					"SELECT count(*) FROM pg_replication_slots rs JOIN spock.subscription sub ON sub.sub_slot_name = rs.slot_name;")
+				if err != nil {
+					t.Fatalf("failed to query replication slots on %s: %v", pod, err)
+				}
+				if strings.TrimSpace(out) != "1" {
+					t.Errorf("pod %s: expected 1 logical replication slot for subscription, got: %s", pod, out)
+				}
+			})
+		}
+	})
+
+	t.Run("data_replicates_with_replicas", func(t *testing.T) {
+		_, err := testKube.ExecSQL("pgedge-n1-1",
+			"CREATE TABLE test_ha (id int PRIMARY KEY, val text);")
+		if err != nil {
+			t.Fatalf("failed to create test table: %v", err)
+		}
+
+		_, err = testKube.ExecSQL("pgedge-n1-1",
+			"INSERT INTO test_ha VALUES (1, 'from-n1');")
+		if err != nil {
+			t.Fatalf("failed to insert on n1: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		t.Run("replicate_to_n2", func(t *testing.T) {
+			err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+				out, err := testKube.ExecSQL("pgedge-n2-1", "SELECT val FROM test_ha WHERE id = 1;")
+				if err != nil {
+					return false, nil
+				}
+				return strings.Contains(out, "from-n1"), nil
+			})
+			if err != nil {
+				t.Error("row did not replicate to n2 within timeout")
+			}
+		})
+
+		_, err = testKube.ExecSQL("pgedge-n2-1",
+			"INSERT INTO test_ha VALUES (2, 'from-n2');")
+		if err != nil {
+			t.Fatalf("failed to insert on n2: %v", err)
+		}
+
+		t.Run("active_active_n1", func(t *testing.T) {
+			err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+				out, err := testKube.ExecSQL("pgedge-n1-1", "SELECT val FROM test_ha WHERE id = 2;")
+				if err != nil {
+					return false, nil
+				}
+				return strings.Contains(out, "from-n2"), nil
+			})
+			if err != nil {
+				t.Error("active-active row did not replicate to n1")
 			}
 		})
 	})

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -315,6 +315,24 @@ func TestDistributedHAInstall(t *testing.T) {
 		}
 	})
 
+	t.Run("debug_replication_state", func(t *testing.T) {
+		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
+			t.Run(pod, func(t *testing.T) {
+				out, _ := testKube.ExecSQL(pod, "SELECT pg_is_in_recovery();")
+				t.Logf("pod %s pg_is_in_recovery: %s", pod, out)
+
+				out, _ = testKube.ExecSQL(pod, "SELECT slot_name, slot_type, active, plugin FROM pg_replication_slots;")
+				t.Logf("pod %s pg_replication_slots:\n%s", pod, out)
+
+				out, _ = testKube.ExecSQL(pod, "SELECT sub_name, sub_slot_name, sub_enabled FROM spock.subscription;")
+				t.Logf("pod %s spock.subscription:\n%s", pod, out)
+
+				out, _ = testKube.ExecSQL(pod, "SELECT node_name FROM spock.node_local;")
+				t.Logf("pod %s spock.node_local: %s", pod, out)
+			})
+		}
+	})
+
 	t.Run("replication_slots_exist", func(t *testing.T) {
 		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
 			t.Run(pod, func(t *testing.T) {

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -151,15 +151,17 @@ func TestDistributedInstall(t *testing.T) {
 	})
 
 	t.Run("replication_slots_exist", func(t *testing.T) {
+		// Each node acts as a provider for its peer's subscription,
+		// so each primary should have exactly 1 logical replication slot.
 		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
 			t.Run(pod, func(t *testing.T) {
 				out, err := testKube.ExecSQL(pod,
-					"SELECT count(*) FROM pg_replication_slots rs JOIN spock.subscription sub ON sub.sub_slot_name = rs.slot_name;")
+					"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical';")
 				if err != nil {
 					t.Fatalf("failed to query replication slots on %s: %v", pod, err)
 				}
 				if strings.TrimSpace(out) != "1" {
-					t.Errorf("pod %s: expected 1 logical replication slot for subscription, got: %s", pod, out)
+					t.Errorf("pod %s: expected 1 logical replication slot, got: %s", pod, out)
 				}
 			})
 		}
@@ -315,34 +317,18 @@ func TestDistributedHAInstall(t *testing.T) {
 		}
 	})
 
-	t.Run("debug_replication_state", func(t *testing.T) {
-		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
-			t.Run(pod, func(t *testing.T) {
-				out, _ := testKube.ExecSQL(pod, "SELECT pg_is_in_recovery();")
-				t.Logf("pod %s pg_is_in_recovery: %s", pod, out)
-
-				out, _ = testKube.ExecSQL(pod, "SELECT slot_name, slot_type, active, plugin FROM pg_replication_slots;")
-				t.Logf("pod %s pg_replication_slots:\n%s", pod, out)
-
-				out, _ = testKube.ExecSQL(pod, "SELECT sub_name, sub_slot_name, sub_enabled FROM spock.subscription;")
-				t.Logf("pod %s spock.subscription:\n%s", pod, out)
-
-				out, _ = testKube.ExecSQL(pod, "SELECT node_name FROM spock.node_local;")
-				t.Logf("pod %s spock.node_local: %s", pod, out)
-			})
-		}
-	})
-
 	t.Run("replication_slots_exist", func(t *testing.T) {
+		// Each node acts as a provider for its peer's subscription,
+		// so each primary should have exactly 1 logical replication slot.
 		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1"} {
 			t.Run(pod, func(t *testing.T) {
 				out, err := testKube.ExecSQL(pod,
-					"SELECT count(*) FROM pg_replication_slots rs JOIN spock.subscription sub ON sub.sub_slot_name = rs.slot_name;")
+					"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical';")
 				if err != nil {
 					t.Fatalf("failed to query replication slots on %s: %v", pod, err)
 				}
 				if strings.TrimSpace(out) != "1" {
-					t.Errorf("pod %s: expected 1 logical replication slot for subscription, got: %s", pod, out)
+					t.Errorf("pod %s: expected 1 logical replication slot, got: %s", pod, out)
 				}
 			})
 		}

--- a/test/integration/multicluster_test.go
+++ b/test/integration/multicluster_test.go
@@ -1,0 +1,275 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pgEdge/pgedge-helm/test/pkg/helm"
+	"github.com/pgEdge/pgedge-helm/test/pkg/kube"
+	"github.com/pgEdge/pgedge-helm/test/pkg/wait"
+)
+
+const (
+	nsClusterA = "mc-cluster-a"
+	nsClusterB = "mc-cluster-b"
+)
+
+// copySecret copies a Kubernetes secret from one namespace to another,
+// stripping metadata that would prevent re-creation.
+func copySecret(t *testing.T, src, dst *kube.Kubectl, secretName, dstNamespace string) {
+	t.Helper()
+	raw, err := src.GetJSON("secret", secretName)
+	if err != nil {
+		t.Fatalf("get secret %s from source: %v", secretName, err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal secret %s: %v", secretName, err)
+	}
+
+	// Strip metadata fields that prevent re-creation
+	if meta, ok := obj["metadata"].(map[string]any); ok {
+		meta["namespace"] = dstNamespace
+		delete(meta, "uid")
+		delete(meta, "resourceVersion")
+		delete(meta, "creationTimestamp")
+		delete(meta, "managedFields")
+		// Remove cert-manager annotations that would confuse cert-manager in dst
+		if annotations, ok := meta["annotations"].(map[string]any); ok {
+			for k := range annotations {
+				if strings.HasPrefix(k, "cert-manager.io/") {
+					delete(annotations, k)
+				}
+			}
+		}
+		// Remove ownerReferences (cert-manager Certificate owns the secret)
+		delete(meta, "ownerReferences")
+	}
+
+	cleaned, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal cleaned secret %s: %v", secretName, err)
+	}
+
+	if err := dst.Apply(string(cleaned)); err != nil {
+		t.Fatalf("apply secret %s to %s: %v", secretName, dstNamespace, err)
+	}
+}
+
+func TestMultiClusterInstall(t *testing.T) {
+	kubeA := &kube.Kubectl{Context: kubeContext, Namespace: nsClusterA}
+	kubeB := &kube.Kubectl{Context: kubeContext, Namespace: nsClusterB}
+	helmA := &helm.Helm{KubeContext: kubeContext, Namespace: nsClusterA}
+	helmB := &helm.Helm{KubeContext: kubeContext, Namespace: nsClusterB}
+
+	t.Cleanup(func() {
+		_ = helmB.Uninstall(helmRelease)
+		_ = helmA.Uninstall(helmRelease)
+		_ = kubeB.DeleteNamespace(nsClusterB)
+		_ = kubeA.DeleteNamespace(nsClusterA)
+	})
+
+	// Step 1: Deploy cluster A (provisionCerts: true, initSpock: false)
+	opts := helm.InstallOpts{
+		ChartRef:        chartRef,
+		Version:         chartVersion,
+		ValuesFiles:     []string{testdataPath("multicluster-a-values.yaml")},
+		Wait:            true,
+		Timeout:         timeout.String(),
+		CreateNamespace: true,
+	}
+	if initSpockImg != "" {
+		opts.SetValues = []string{fmt.Sprintf("pgEdge.initSpockImageName=%s", initSpockImg)}
+	}
+	if err := helmA.Install(helmRelease, opts); err != nil {
+		t.Fatalf("helm install cluster-a failed: %v", err)
+	}
+
+	t.Run("cluster_a_healthy", func(t *testing.T) {
+		if err := wait.ForClusterHealthy(kubeA, "pgedge-n1", timeout); err != nil {
+			t.Fatalf("cluster pgedge-n1 not healthy: %v", err)
+		}
+	})
+
+	// Step 2: Wait for certs to be issued in cluster A
+	t.Run("cluster_a_certs_ready", func(t *testing.T) {
+		certs := []string{
+			"client-ca",
+			"streaming-replica-client-cert",
+			"pgedge-client-cert",
+			"admin-client-cert",
+			"app-client-cert",
+		}
+		for _, cert := range certs {
+			if err := wait.ForCertReady(kubeA, cert, timeout); err != nil {
+				t.Fatalf("certificate %s not ready in cluster-a: %v", cert, err)
+			}
+		}
+	})
+
+	// Step 3: Copy cert secrets from cluster A → cluster B
+	t.Run("copy_certs_to_cluster_b", func(t *testing.T) {
+		if err := kubeA.CreateNamespace(nsClusterB); err != nil {
+			t.Fatalf("create namespace %s: %v", nsClusterB, err)
+		}
+
+		secrets := []string{
+			"client-ca-key-pair",
+			"streaming-replica-client-cert",
+			"pgedge-client-cert",
+			"admin-client-cert",
+			"app-client-cert",
+		}
+		for _, s := range secrets {
+			copySecret(t, kubeA, kubeB, s, nsClusterB)
+		}
+	})
+
+	// Step 4: Deploy cluster B (provisionCerts: false, initSpock: true)
+	optsB := helm.InstallOpts{
+		ChartRef:    chartRef,
+		Version:     chartVersion,
+		ValuesFiles: []string{testdataPath("multicluster-b-values.yaml")},
+		Wait:        true,
+		Timeout:     timeout.String(),
+	}
+	if initSpockImg != "" {
+		optsB.SetValues = []string{fmt.Sprintf("pgEdge.initSpockImageName=%s", initSpockImg)}
+	}
+	if err := helmB.Install(helmRelease, optsB); err != nil {
+		t.Fatalf("helm install cluster-b failed: %v", err)
+	}
+
+	t.Run("cluster_b_healthy", func(t *testing.T) {
+		if err := wait.ForClusterHealthy(kubeB, "pgedge-n2", timeout); err != nil {
+			t.Fatalf("cluster pgedge-n2 not healthy: %v", err)
+		}
+	})
+
+	t.Run("init_spock_job_succeeds", func(t *testing.T) {
+		if err := wait.ForJobComplete(kubeB, "pgedge-init-spock", timeout); err != nil {
+			logs, _ := kubeB.Logs("job/pgedge-init-spock")
+			t.Fatalf("init-spock job failed: %v\nlogs:\n%s", err, logs)
+		}
+	})
+
+	// Assertions
+	t.Run("spock_nodes_on_both", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			kube *kube.Kubectl
+			pod  string
+		}{
+			{"cluster_a", kubeA, "pgedge-n1-1"},
+			{"cluster_b", kubeB, "pgedge-n2-1"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				out, err := tc.kube.ExecSQL(tc.pod, "SELECT node_name FROM spock.node ORDER BY node_name;")
+				if err != nil {
+					t.Fatalf("failed to query spock.node on %s: %v", tc.pod, err)
+				}
+				for _, expected := range []string{"n1", "n2"} {
+					if !strings.Contains(out, expected) {
+						t.Errorf("%s: spock.node missing %s, got: %s", tc.pod, expected, out)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("dsn_uses_fqdn", func(t *testing.T) {
+		expected := map[string]string{
+			"n1": "pgedge-n1-rw.mc-cluster-a.svc.cluster.local",
+			"n2": "pgedge-n2-rw.mc-cluster-b.svc.cluster.local",
+		}
+		for node, hostname := range expected {
+			t.Run(node, func(t *testing.T) {
+				out, err := kubeA.ExecSQL("pgedge-n1-1",
+					"SELECT if_dsn FROM spock.node_interface WHERE if_nodeid = (SELECT node_id FROM spock.node WHERE node_name = '"+node+"');")
+				if err != nil {
+					t.Fatalf("failed to query DSN for %s: %v", node, err)
+				}
+				if !strings.Contains(out, "host="+hostname) {
+					t.Errorf("expected DSN to contain host=%s, got: %s", hostname, out)
+				}
+			})
+		}
+	})
+
+	t.Run("subscriptions_bidirectional", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			kube *kube.Kubectl
+			pod  string
+		}{
+			{"cluster_a", kubeA, "pgedge-n1-1"},
+			{"cluster_b", kubeB, "pgedge-n2-1"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				out, err := tc.kube.ExecSQL(tc.pod, "SELECT count(*) FROM spock.subscription;")
+				if err != nil {
+					t.Fatalf("failed to query subscription count on %s: %v", tc.pod, err)
+				}
+				if strings.TrimSpace(out) != "1" {
+					t.Errorf("%s: expected 1 subscription, got: %s", tc.pod, out)
+				}
+			})
+		}
+	})
+
+	t.Run("data_replicates_cross_namespace", func(t *testing.T) {
+		_, err := kubeA.ExecSQL("pgedge-n1-1",
+			"CREATE TABLE test_mc (id int PRIMARY KEY, val text);")
+		if err != nil {
+			t.Fatalf("failed to create test table on n1: %v", err)
+		}
+
+		_, err = kubeA.ExecSQL("pgedge-n1-1",
+			"INSERT INTO test_mc VALUES (1, 'from-cluster-a');")
+		if err != nil {
+			t.Fatalf("failed to insert on n1: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		t.Run("a_to_b", func(t *testing.T) {
+			err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+				out, err := kubeB.ExecSQL("pgedge-n2-1", "SELECT val FROM test_mc WHERE id = 1;")
+				if err != nil {
+					return false, nil
+				}
+				return strings.Contains(out, "from-cluster-a"), nil
+			})
+			if err != nil {
+				t.Error("row did not replicate from cluster-a to cluster-b")
+			}
+		})
+
+		_, err = kubeB.ExecSQL("pgedge-n2-1",
+			"INSERT INTO test_mc VALUES (2, 'from-cluster-b');")
+		if err != nil {
+			t.Fatalf("failed to insert on n2: %v", err)
+		}
+
+		t.Run("b_to_a", func(t *testing.T) {
+			err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+				out, err := kubeA.ExecSQL("pgedge-n1-1", "SELECT val FROM test_mc WHERE id = 2;")
+				if err != nil {
+					return false, nil
+				}
+				return strings.Contains(out, "from-cluster-b"), nil
+			})
+			if err != nil {
+				t.Error("row did not replicate from cluster-b to cluster-a")
+			}
+		})
+	})
+}

--- a/test/integration/nodes_test.go
+++ b/test/integration/nodes_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -89,11 +90,85 @@ func TestNodesAddNode(t *testing.T) {
 		}
 	})
 
-	t.Run("n3_replicates_new_data", func(t *testing.T) {
+	t.Run("full_mesh_replication", func(t *testing.T) {
+		// Insert a row on each node and verify it reaches all others
+		writes := map[string]int{
+			"pgedge-n1-1": 10,
+			"pgedge-n2-1": 11,
+			"pgedge-n3-1": 12,
+		}
+		for pod, id := range writes {
+			_, err := testKube.ExecSQL(pod,
+				fmt.Sprintf("INSERT INTO test_add_node VALUES (%d, 'from-%s');", id, pod))
+			if err != nil {
+				t.Fatalf("failed to insert on %s: %v", pod, err)
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		for srcPod, id := range writes {
+			for _, dstPod := range []string{"pgedge-n1-1", "pgedge-n2-1", "pgedge-n3-1"} {
+				if dstPod == srcPod {
+					continue
+				}
+				t.Run(fmt.Sprintf("%s_to_%s", srcPod, dstPod), func(t *testing.T) {
+					expected := fmt.Sprintf("from-%s", srcPod)
+					err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+						out, err := testKube.ExecSQL(dstPod,
+							fmt.Sprintf("SELECT val FROM test_add_node WHERE id = %d;", id))
+						if err != nil {
+							return false, nil
+						}
+						return strings.Contains(out, expected), nil
+					})
+					if err != nil {
+						t.Errorf("data from %s (id=%d) did not replicate to %s", srcPod, id, dstPod)
+					}
+				})
+			}
+		}
+	})
+
+	t.Run("idempotent_rerun_on_3_nodes", func(t *testing.T) {
+		// Record subscription IDs before re-run
+		subsBefore := map[string]string{}
+		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1", "pgedge-n3-1"} {
+			out, err := testKube.ExecSQL(pod,
+				"SELECT sub_id, sub_name FROM spock.subscription ORDER BY sub_name;")
+			if err != nil {
+				t.Fatalf("failed to query subscriptions on %s: %v", pod, err)
+			}
+			subsBefore[pod] = strings.TrimSpace(out)
+		}
+
+		// Re-run init-spock on the 3-node cluster (steady-state values, no bootstrap)
+		upgradeChart(t, "distributed-3node-values.yaml")
+
+		if err := wait.ForJobComplete(testKube, "pgedge-init-spock", timeout); err != nil {
+			logs, _ := testKube.Logs("job/pgedge-init-spock")
+			t.Fatalf("init-spock re-run failed: %v\nlogs:\n%s", err, logs)
+		}
+
+		// Verify subscriptions were not recreated
+		for _, pod := range []string{"pgedge-n1-1", "pgedge-n2-1", "pgedge-n3-1"} {
+			out, err := testKube.ExecSQL(pod,
+				"SELECT sub_id, sub_name FROM spock.subscription ORDER BY sub_name;")
+			if err != nil {
+				t.Fatalf("failed to query subscriptions on %s after re-run: %v", pod, err)
+			}
+			if strings.TrimSpace(out) != subsBefore[pod] {
+				t.Errorf("%s: subscriptions changed after re-run\nbefore: %s\nafter:  %s",
+					pod, subsBefore[pod], strings.TrimSpace(out))
+			}
+		}
+
+		// Verify replication still works
 		_, err := testKube.ExecSQL("pgedge-n3-1",
-			"INSERT INTO test_add_node VALUES (2, 'from-n3');")
+			"INSERT INTO test_add_node VALUES (20, 'after-rerun');")
 		if err != nil {
-			t.Fatalf("failed to insert on n3: %v", err)
+			t.Fatalf("failed to insert after re-run: %v", err)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -101,14 +176,14 @@ func TestNodesAddNode(t *testing.T) {
 
 		err = wait.Until(ctx, 2*time.Second, func() (bool, error) {
 			out, err := testKube.ExecSQL("pgedge-n1-1",
-				"SELECT val FROM test_add_node WHERE id = 2;")
+				"SELECT val FROM test_add_node WHERE id = 20;")
 			if err != nil {
 				return false, nil
 			}
-			return strings.Contains(out, "from-n3"), nil
+			return strings.Contains(out, "after-rerun"), nil
 		})
 		if err != nil {
-			t.Error("new data from n3 did not replicate to n1")
+			t.Error("replication broken after idempotent re-run")
 		}
 	})
 }

--- a/test/integration/testdata/distributed-ha-values.yaml
+++ b/test/integration/testdata/distributed-ha-values.yaml
@@ -1,0 +1,11 @@
+pgEdge:
+  appName: pgedge
+  nodes:
+    - name: n1
+      hostname: pgedge-n1-rw
+    - name: n2
+      hostname: pgedge-n2-rw
+  clusterSpec:
+    instances: 3
+    storage:
+      size: 1Gi

--- a/test/integration/testdata/multicluster-a-values.yaml
+++ b/test/integration/testdata/multicluster-a-values.yaml
@@ -1,0 +1,14 @@
+pgEdge:
+  appName: pgedge
+  provisionCerts: true
+  initSpock: false
+  nodes:
+    - name: n1
+      hostname: pgedge-n1-rw.mc-cluster-a.svc.cluster.local
+      internalHostname: pgedge-n1-rw
+  externalNodes:
+    - name: n2
+      hostname: pgedge-n2-rw.mc-cluster-b.svc.cluster.local
+  clusterSpec:
+    storage:
+      size: 1Gi

--- a/test/integration/testdata/multicluster-b-values.yaml
+++ b/test/integration/testdata/multicluster-b-values.yaml
@@ -1,0 +1,14 @@
+pgEdge:
+  appName: pgedge
+  provisionCerts: false
+  initSpock: true
+  nodes:
+    - name: n2
+      hostname: pgedge-n2-rw.mc-cluster-b.svc.cluster.local
+      internalHostname: pgedge-n2-rw
+  externalNodes:
+    - name: n1
+      hostname: pgedge-n1-rw.mc-cluster-a.svc.cluster.local
+  clusterSpec:
+    storage:
+      size: 1Gi

--- a/test/pkg/helm/helm.go
+++ b/test/pkg/helm/helm.go
@@ -14,12 +14,13 @@ type Helm struct {
 
 // InstallOpts configures a helm install or upgrade.
 type InstallOpts struct {
-	ChartRef    string   // local path, OCI URI, or repo/chart
-	Version     string   // --version flag (empty = omit)
-	ValuesFiles []string // -f flags
-	SetValues   []string // --set key=value
-	Wait        bool
-	Timeout     string // --timeout flag (e.g. "10m"), requires Wait
+	ChartRef        string   // local path, OCI URI, or repo/chart
+	Version         string   // --version flag (empty = omit)
+	ValuesFiles     []string // -f flags
+	SetValues       []string // --set key=value
+	Wait            bool
+	Timeout         string // --timeout flag (e.g. "10m"), requires Wait
+	CreateNamespace bool   // --create-namespace flag
 }
 
 // UpgradeOpts configures a helm upgrade (same shape as InstallOpts).
@@ -96,6 +97,9 @@ func (h *Helm) appendOpts(args []string, opts InstallOpts) []string {
 	}
 	for _, s := range opts.SetValues {
 		args = append(args, "--set", s)
+	}
+	if opts.CreateNamespace {
+		args = append(args, "--create-namespace")
 	}
 	if opts.Wait {
 		args = append(args, "--wait")

--- a/test/pkg/kube/kube.go
+++ b/test/pkg/kube/kube.go
@@ -140,6 +140,38 @@ func (k *Kubectl) ConnectWithCert(service, certSecret, user, db, sql string) (st
 	return k.run(args...)
 }
 
+// CreateNamespace creates a Kubernetes namespace.
+func (k *Kubectl) CreateNamespace(name string) error {
+	args := []string{"create", "namespace", name}
+	if k.Context != "" {
+		args = append([]string{"--context", k.Context}, args...)
+	}
+	_, err := k.run(args...)
+	return err
+}
+
+// DeleteNamespace deletes a Kubernetes namespace.
+func (k *Kubectl) DeleteNamespace(name string) error {
+	args := []string{"delete", "namespace", name, "--ignore-not-found"}
+	if k.Context != "" {
+		args = append([]string{"--context", k.Context}, args...)
+	}
+	_, err := k.run(args...)
+	return err
+}
+
+// Apply pipes input to kubectl apply -f -.
+func (k *Kubectl) Apply(input string) error {
+	args := append(k.baseArgs(), "apply", "-f", "-")
+	cmd := exec.Command("kubectl", args...)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl apply failed: %w\n%s", err, string(out))
+	}
+	return nil
+}
+
 func (k *Kubectl) run(args ...string) (string, error) {
 	cmd := exec.Command("kubectl", args...)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Adds E2E integration tests for three deployment configurations that previously had zero coverage:

- HA with streaming replicas
  - verifies Spock logical replication works correctly alongside CNPG physical streaming replication, including cluster health checks with multiple instances
- Multi-cluster with external nodes
  - simulates a two-cluster deployment using separate Kubernetes namespaces, testing `externalNodes`, `internalHostname` routing, `provisionCerts: false`, cross-namespace certificate copying, and bidirectional Spock replication across namespace boundaries
- Replication slot verification
  - asserts that every Spock subscription has a matching `pg_replication_slots` entry
- Full mesh and idempotency checks for add-node
  - after adding n3, verifies all 6 replication paths in the 3-node mesh (each node's data reaches both others). Then re-runs init-spock on the steady-state 3-node config and confirms subscriptions are not recreated (same sub_id) and replication is unbroken.

Also extends the test helper packages with `CreateNamespace`, `DeleteNamespace`, `Apply`, and `CreateNamespace` (Helm) to support multi-namespace test scenarios.