### PR TITLE
fix: invoke release workflow directly from tag-release via workflow_call

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 jobs:
   release:
@@ -25,10 +30,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
+      - name: Resolve version
         id: version
         run: |
-          VERSION=${GITHUB_REF_NAME}
+          VERSION="${{ inputs.version || github.ref_name }}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           # Strip v prefix for CHART_VERSION (used for helm package and docker image)
           CHART_VERSION=${VERSION#v}

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -22,6 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Tag release
+        id: tag
         env:
           branch_name: ${{ github.event.pull_request.head.ref }}
         run: |
@@ -38,3 +41,12 @@ jobs:
 
           git tag -a -F changes/${version}.md ${version}
           git push origin ${version}
+
+          echo "version=${version}" >> $GITHUB_OUTPUT
+
+  release:
+    needs: tag-release
+    uses: ./.github/workflows/release.yaml
+    with:
+      version: ${{ needs.tag-release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

The release workflow never ran after merging a `release/*` PR because `tag-release.yaml` pushes the tag using `GITHUB_TOKEN`, and [GitHub silently drops events triggered by `GITHUB_TOKEN`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow) to prevent infinite workflow loops.

## Changes

- **`tag-release.yaml`** — now calls `release.yaml` directly via `workflow_call` after pushing the tag, instead of relying on the push event to trigger it
- **`release.yaml`** — accepts a `workflow_call` trigger with a `version` input, falling back to `github.ref_name` for manual tag pushes

## How it works

| Path | Flow |
|------|------|
| Merged `release/*` PR | `tag-release` → creates tag → calls `release.yaml` via `workflow_call` |
| Manual tag push (e.g. RC) | `release.yaml` triggers directly via `on: push: tags` |

No double execution on the PR path — the `GITHUB_TOKEN` tag push is suppressed, so only the `workflow_call` invocation runs.
