### PR TITLE
docs: add missed changelog entries for v1.0.0

### DIFF
--- a/changes/unreleased/Added-20260416-155002.yaml
+++ b/changes/unreleased/Added-20260416-155002.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous behavior which required stopping writes during `helm upgrade` (#52)
+time: 2026-04-16T15:50:02.825165-05:00

--- a/changes/unreleased/Added-20260416-155011.yaml
+++ b/changes/unreleased/Added-20260416-155011.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
+time: 2026-04-16T15:50:11.305881-05:00

--- a/changes/unreleased/Changed-20260416-155011.yaml
+++ b/changes/unreleased/Changed-20260416-155011.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined, copy-paste-and-go guide that assumes a working cluster (#46)
+time: 2026-04-16T15:50:11.328-05:00

--- a/changes/unreleased/Changed-20260416-155041.yaml
+++ b/changes/unreleased/Changed-20260416-155041.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release (#51)
+time: 2026-04-16T15:50:41.16161-05:00

--- a/changes/unreleased/Changed-20260416-155044.yaml
+++ b/changes/unreleased/Changed-20260416-155044.yaml
@@ -1,3 +1,3 @@
 kind: Changed
-body: Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
+body: Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired state. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
 time: 2026-04-16T15:50:44.776041-05:00

--- a/changes/unreleased/Changed-20260416-155044.yaml
+++ b/changes/unreleased/Changed-20260416-155044.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
+time: 2026-04-16T15:50:44.776041-05:00


### PR DESCRIPTION
Add missing changelog entries for merged PRs.

     ### Added

     - Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue
     uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous
     behavior which required stopping writes during `helm upgrade` (#52)
     - Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available
     as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
     - Added the ability to configure the database name, owner, and admin role via Helm values
     (`initdb.database`, `initdb.owner`, `pgEdge.adminUser`). Also added documentation covering all managed
     users, their authentication methods, and how to create additional users or disable passwords (#54)

     ### Changed

     - Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined,
     copy-paste-and-go guide that assumes a working cluster (#46)
     - Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release
     (#51)
     - Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual
     state and converges toward desired state. Includes parallel execution within dependency phases and reduces the
     Docker image from ~150MB to ~15MB (#50)