### PR TITLE
fix: CI workflow permissions and E2E secret cleanup

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -46,6 +46,9 @@ jobs:
 
   release:
     needs: tag-release
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/release.yaml
     with:
       version: ${{ needs.tag-release.outputs.version }}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -148,6 +148,13 @@ func uninstallChart(t *testing.T) {
 			t.Fatalf("cleanup failed: %s with label %s not fully deleted: %v", resource, label, err)
 		}
 	}
+	// CNPG-managed secrets (CA, server TLS) are owned by the Cluster resource and
+	// garbage collected asynchronously. If stale secrets persist into the next test,
+	// the new cluster's CA won't match the old server cert, causing permanent TLS
+	// handshake failures ("x509: ECDSA verification failure").
+	if err := testKube.WaitForDelete("secrets", "cnpg.io/cluster", timeout); err != nil {
+		t.Fatalf("cleanup failed: CNPG-managed secrets not fully deleted: %v", err)
+	}
 }
 
 func getPodName(clusterName string) string {


### PR DESCRIPTION
## Summary

- **Grant `contents: write` and `packages: write` to the `release` job in `tag-release.yaml`.**
  When calling `release.yaml` via `workflow_call`, the called workflow's permissions
  are capped by the caller. The `release` job had no explicit permissions, so it
  defaulted to the `pull_request` trigger's read-only scope, failing validation even
  when the job was skipped by its `if` condition.

- **Wait for CNPG-managed secrets to be garbage collected between E2E tests.**
  `TestNodesAddNodeZeroDowntime` was timing out on every open PR because
  `uninstallChart()` only waited for clusters, pods, jobs, and PVCs — not the
  operator-generated secrets (`<cluster>-ca`, `<cluster>-server`). These are owned
  by the Cluster resource and GC'd asynchronously. When the next test reused the
  same cluster names, the new CA didn't match the stale server cert, causing a
  permanent `x509: ECDSA verification failure` between the operator and instance.
