### PR TITLE
feat: harden add-node workflow for data safety, add failover test

### DIFF
--- a/internal/spock/desired.go
+++ b/internal/spock/desired.go
@@ -22,6 +22,8 @@ const (
 	ResourceTypeLagTrackerCommitTS            = "spock.lag_tracker_commit_ts"
 	ResourceTypeReplicationSlotAdvanceFromCTS = "spock.replication_slot_advance_from_cts"
 	ResourceTypeDisabledSubscription          = "spock.disabled_subscription"
+	ResourceTypeReplicationOriginAdvance      = "spock.replication_origin_advance"
+	ResourceTypePeerCatchup                   = "spock.peer_catchup"
 )
 
 // ComputeDesired builds the full resource graph from node config.
@@ -73,9 +75,11 @@ func ComputeDesired(cfg *config.Config, conns map[string]*pgxpool.Pool) map[reso
 			var extraDeps []resource.Identifier
 
 			if _, isNewDst := newNodes[dst.Name]; isNewDst {
-				// Peer→new: wait for slot advance
+				// Peer→new: wait for origin advance (which itself waits on slot
+				// advance — both must complete before enabling the subscription
+				// to keep slot LSN and origin LSN in lockstep).
 				extraDeps = append(extraDeps, resource.Identifier{
-					Type: ResourceTypeReplicationSlotAdvanceFromCTS,
+					Type: ResourceTypeReplicationOriginAdvance,
 					ID:   fmt.Sprintf("%s_%s", src.Name, dst.Name),
 				})
 			}
@@ -97,8 +101,8 @@ func ComputeDesired(cfg *config.Config, conns map[string]*pgxpool.Pool) map[reso
 }
 
 // addPopulateResources emits the populate resource chain for a new node.
-// Returns the identifiers of peer WaitForSyncEvent resources (used to
-// gate the source→new subscription).
+// Returns the identifiers of peer-side gates (WaitForSyncEvent + PeerCatchup
+// per peer) that the source→new subscription must wait on before COPY.
 func addPopulateResources(
 	resources map[resource.Identifier]resource.Resource,
 	cfg *config.Config,
@@ -131,6 +135,13 @@ func addPopulateResources(
 		resources[peerWaitEvt.Identifier()] = peerWaitEvt
 		peerWaitForSync = append(peerWaitForSync, peerWaitEvt.Identifier())
 
+		// Belt-and-suspenders: also wait on apply progress via
+		// spock.progress.remote_lsn, which tracks actual commit application
+		// rather than WAL receipt. Gates the source→new COPY.
+		peerCatchup := NewPeerCatchup(peer.Name, sourceNode, peerSyncEvt, conns[sourceNode])
+		resources[peerCatchup.Identifier()] = peerCatchup
+		peerWaitForSync = append(peerWaitForSync, peerCatchup.Identifier())
+
 		lagTracker := NewLagTrackerCommitTimestamp(peer.Name, newNode.Name, conns[newNode.Name],
 			resource.Identifier{Type: ResourceTypeWaitForSyncEvent, ID: fmt.Sprintf("%s_%s", sourceNode, newNode.Name)},
 		)
@@ -138,6 +149,13 @@ func addPopulateResources(
 
 		slotAdvance := NewReplicationSlotAdvanceFromCTS(peer.Name, newNode.Name, cfg.DBName, lagTracker, conns[peer.Name])
 		resources[slotAdvance.Identifier()] = slotAdvance
+
+		// Subscriber-side origin advance. Separate from slot advance because
+		// the slot lives on the provider and the origin on the subscriber —
+		// different connections. Both must agree to prevent the apply worker
+		// from replaying historical WAL from 0/0.
+		originAdvance := NewReplicationOriginAdvance(peer.Name, newNode.Name, cfg.DBName, slotAdvance, conns[newNode.Name])
+		resources[originAdvance.Identifier()] = originAdvance
 	}
 
 	// Source sync event + wait

--- a/internal/spock/peer_catchup.go
+++ b/internal/spock/peer_catchup.go
@@ -1,0 +1,113 @@
+// internal/spock/peer_catchup.go
+package spock
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgEdge/pgedge-helm/internal/resource"
+)
+
+const peerCatchupPollInterval = 500 * time.Millisecond
+
+// PeerCatchup waits until the source node's apply progress from the peer
+// node has reached the peer's sync event LSN. This ensures the source→new
+// COPY snapshot includes all peer writes up to the slot creation point,
+// preventing data loss on add-node.
+//
+// Uses spock.progress.remote_lsn (apply progress at last committed
+// transaction) rather than received_lsn, which can advance on keepalive
+// messages before commits have been applied.
+//
+// Reads the target LSN from the paired SyncEvent (peer→source) via
+// struct pointer.
+//
+// Ephemeral — re-executes every run.
+type PeerCatchup struct {
+	peerName   string
+	sourceName string
+	syncEvent  *SyncEvent
+	conn       *pgxpool.Pool // source's connection
+	status     resource.Status
+}
+
+func NewPeerCatchup(peerName, sourceName string, syncEvent *SyncEvent, conn *pgxpool.Pool) *PeerCatchup {
+	return &PeerCatchup{
+		peerName:   peerName,
+		sourceName: sourceName,
+		syncEvent:  syncEvent,
+		conn:       conn,
+	}
+}
+
+func (r *PeerCatchup) Identifier() resource.Identifier {
+	return resource.Identifier{
+		Type: ResourceTypePeerCatchup,
+		ID:   fmt.Sprintf("%s_%s", r.peerName, r.sourceName),
+	}
+}
+
+func (r *PeerCatchup) Dependencies() []resource.Identifier {
+	return []resource.Identifier{
+		{Type: ResourceTypeSyncEvent, ID: fmt.Sprintf("%s_%s", r.peerName, r.sourceName)},
+	}
+}
+
+func (r *PeerCatchup) Refresh(_ context.Context) error {
+	r.status = resource.Status{Exists: false}
+	return nil
+}
+
+func (r *PeerCatchup) Status() resource.Status { return r.status }
+
+func (r *PeerCatchup) Create(ctx context.Context) error {
+	if r.syncEvent == nil || r.syncEvent.LSN == "" {
+		return fmt.Errorf("sync event LSN not available for peer catchup %s→%s",
+			r.peerName, r.sourceName)
+	}
+
+	slog.Info("waiting for peer apply to catch up",
+		"peer", r.peerName, "source", r.sourceName, "target_lsn", r.syncEvent.LSN)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var reached bool
+		err := r.conn.QueryRow(ctx, `
+			SELECT COALESCE(
+				(SELECT p.remote_lsn >= $1::pg_lsn
+				 FROM spock.progress p
+				 JOIN spock.node n ON n.node_id = p.remote_node_id
+				 WHERE p.node_id = (SELECT node_id FROM spock.node_info())
+				   AND n.node_name = $2),
+				false
+			)`, r.syncEvent.LSN, r.peerName,
+		).Scan(&reached)
+		if err != nil {
+			return fmt.Errorf("query spock.progress on %s for peer %s: %w",
+				r.sourceName, r.peerName, err)
+		}
+
+		if reached {
+			slog.Info("peer apply caught up",
+				"peer", r.peerName, "source", r.sourceName, "target_lsn", r.syncEvent.LSN)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(peerCatchupPollInterval):
+		}
+	}
+}
+
+func (r *PeerCatchup) Update(_ context.Context) error { return nil }
+
+func (r *PeerCatchup) Delete(_ context.Context) error { return nil }

--- a/internal/spock/replication_origin_advance.go
+++ b/internal/spock/replication_origin_advance.go
@@ -1,0 +1,109 @@
+// internal/spock/replication_origin_advance.go
+package spock
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgEdge/pgedge-helm/internal/resource"
+)
+
+// ReplicationOriginAdvance advances pg_replication_origin on the subscriber
+// to the LSN ReplicationSlotAdvanceFromCTS just advanced the provider-side
+// slot to. The slot (provider) and origin (subscriber) must agree to prevent
+// the apply worker from replaying historical WAL from 0/0.
+//
+// Separate from ReplicationSlotAdvanceFromCTS because the slot lives on the
+// provider and the origin on the subscriber — they use different connections.
+//
+// Reads the target LSN from the paired ReplicationSlotAdvanceFromCTS via
+// struct pointer. No-ops when AdvancedToLSN is empty (slot advance was
+// skipped because slot active, no commit_ts, or already at target).
+//
+// Ephemeral — re-executes every run.
+type ReplicationOriginAdvance struct {
+	providerName   string
+	subscriberName string
+	dbName         string
+	slotAdvance    *ReplicationSlotAdvanceFromCTS
+	conn           *pgxpool.Pool // subscriber's connection
+	status         resource.Status
+}
+
+func NewReplicationOriginAdvance(providerName, subscriberName, dbName string, slotAdvance *ReplicationSlotAdvanceFromCTS, conn *pgxpool.Pool) *ReplicationOriginAdvance {
+	return &ReplicationOriginAdvance{
+		providerName:   providerName,
+		subscriberName: subscriberName,
+		dbName:         dbName,
+		slotAdvance:    slotAdvance,
+		conn:           conn,
+	}
+}
+
+// originName returns the replication origin name. By Spock convention the
+// origin matches the slot name (spk_<db>_<provider>_sub_<provider>_<subscriber>),
+// so we reuse spockSlotName.
+func (r *ReplicationOriginAdvance) originName() string {
+	return spockSlotName(r.dbName, r.providerName, r.subscriberName)
+}
+
+func (r *ReplicationOriginAdvance) Identifier() resource.Identifier {
+	return resource.Identifier{
+		Type: ResourceTypeReplicationOriginAdvance,
+		ID:   fmt.Sprintf("%s_%s", r.providerName, r.subscriberName),
+	}
+}
+
+func (r *ReplicationOriginAdvance) Dependencies() []resource.Identifier {
+	return []resource.Identifier{
+		{Type: ResourceTypeReplicationSlotAdvanceFromCTS, ID: fmt.Sprintf("%s_%s", r.providerName, r.subscriberName)},
+	}
+}
+
+func (r *ReplicationOriginAdvance) Refresh(_ context.Context) error {
+	r.status = resource.Status{Exists: false}
+	return nil
+}
+
+func (r *ReplicationOriginAdvance) Status() resource.Status { return r.status }
+
+func (r *ReplicationOriginAdvance) Create(ctx context.Context) error {
+	if r.slotAdvance == nil || r.slotAdvance.AdvancedToLSN == "" {
+		slog.Info("slot advance was skipped, no origin to advance",
+			"provider", r.providerName, "subscriber", r.subscriberName)
+		return nil
+	}
+
+	originName := r.originName()
+	targetLSN := r.slotAdvance.AdvancedToLSN
+
+	// Create the origin if it doesn't already exist. spock.sub_create
+	// usually creates it, but the NOT EXISTS guard makes this safe in
+	// any ordering. Matches upstream's EnsureReplicationOriginExists.
+	_, err := r.conn.Exec(ctx, `
+		SELECT pg_replication_origin_create($1)
+		WHERE NOT EXISTS (
+			SELECT 1 FROM pg_replication_origin WHERE roname = $1
+		)`, originName)
+	if err != nil {
+		return fmt.Errorf("ensure replication origin %s: %w", originName, err)
+	}
+
+	_, err = r.conn.Exec(ctx,
+		"SELECT pg_replication_origin_advance($1, $2::pg_lsn)",
+		originName, targetLSN,
+	)
+	if err != nil {
+		return fmt.Errorf("advance replication origin %s to %s: %w", originName, targetLSN, err)
+	}
+
+	slog.Info("advanced replication origin", "origin", originName, "to", targetLSN)
+	return nil
+}
+
+func (r *ReplicationOriginAdvance) Update(_ context.Context) error { return nil }
+
+func (r *ReplicationOriginAdvance) Delete(_ context.Context) error { return nil }

--- a/internal/spock/replication_slot_advance.go
+++ b/internal/spock/replication_slot_advance.go
@@ -112,6 +112,8 @@ func (r *ReplicationSlotAdvanceFromCTS) Create(ctx context.Context) error {
 
 	// Read current slot position. Skip if target is at or before current
 	// (slots never go backwards, so this is safe without a transaction).
+	// Compare via pg_lsn casts because LSN strings (e.g. "F/FFFFFFF" vs
+	// "10/0") do not order correctly under Go string comparison.
 	var currentLSN string
 	err = r.conn.QueryRow(ctx,
 		"SELECT restart_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
@@ -120,7 +122,15 @@ func (r *ReplicationSlotAdvanceFromCTS) Create(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("read current slot lsn %s: %w", slotName, err)
 	}
-	if targetLSN <= currentLSN {
+	var atOrBefore bool
+	err = r.conn.QueryRow(ctx,
+		"SELECT $1::pg_lsn <= $2::pg_lsn",
+		targetLSN, currentLSN,
+	).Scan(&atOrBefore)
+	if err != nil {
+		return fmt.Errorf("compare slot lsn %s: %w", slotName, err)
+	}
+	if atOrBefore {
 		slog.Info("slot already at or beyond target, no advance needed",
 			"slot", slotName, "target", targetLSN, "current", currentLSN)
 		return nil

--- a/internal/spock/replication_slot_advance.go
+++ b/internal/spock/replication_slot_advance.go
@@ -11,9 +11,16 @@ import (
 	"github.com/pgEdge/pgedge-helm/internal/resource"
 )
 
-// ReplicationSlotAdvanceFromCTS advances a peer's replication slot to skip
-// WAL already synced via the source. Reads the commit timestamp from the
-// paired LagTrackerCommitTimestamp via struct pointer.
+// ReplicationSlotAdvanceFromCTS advances the provider-side replication slot
+// to the LSN derived from the commit timestamp captured by the paired
+// LagTrackerCommitTimestamp. Used during add-node populate to skip WAL the
+// subscriber has already received via the source path, preventing
+// double-apply when the peer→new subscription is enabled.
+//
+// AdvancedToLSN is set to the new LSN on a successful advance, empty when
+// skipped. ReplicationOriginAdvance reads it to keep the subscriber-side
+// origin in lockstep.
+//
 // Ephemeral resource — re-executes every run.
 type ReplicationSlotAdvanceFromCTS struct {
 	providerName   string // peer node (slot lives here)
@@ -22,6 +29,12 @@ type ReplicationSlotAdvanceFromCTS struct {
 	lagTracker     *LagTrackerCommitTimestamp
 	conn           *pgxpool.Pool // peer's connection
 	status         resource.Status
+
+	// AdvancedToLSN records the LSN the slot was advanced to.
+	// Empty when the advance was skipped (slot active, no commit_ts,
+	// or target ≤ current). Read by ReplicationOriginAdvance to keep
+	// the subscriber-side origin in lockstep with the provider-side slot.
+	AdvancedToLSN string
 }
 
 func NewReplicationSlotAdvanceFromCTS(providerName, subscriberName, dbName string, lagTracker *LagTrackerCommitTimestamp, conn *pgxpool.Pool) *ReplicationSlotAdvanceFromCTS {
@@ -60,6 +73,10 @@ func (r *ReplicationSlotAdvanceFromCTS) Refresh(_ context.Context) error {
 func (r *ReplicationSlotAdvanceFromCTS) Status() resource.Status { return r.status }
 
 func (r *ReplicationSlotAdvanceFromCTS) Create(ctx context.Context) error {
+	// Reset before each invocation so the empty-when-skipped contract
+	// holds for every skip path (no commit_ts, active slot, target ≤ current).
+	r.AdvancedToLSN = ""
+
 	slotName := r.slotName()
 
 	if r.lagTracker == nil || r.lagTracker.CommitTS == nil || r.lagTracker.CommitTS.IsZero() {
@@ -78,7 +95,8 @@ func (r *ReplicationSlotAdvanceFromCTS) Create(ctx context.Context) error {
 		return fmt.Errorf("get target LSN from commit_ts for %s: %w", slotName, err)
 	}
 
-	// Check if slot is actively used by a subscription — skip if yes
+	// Skip if slot is actively used by a subscription — subscription is
+	// already replicating and will advance the slot itself.
 	var isActive bool
 	err = r.conn.QueryRow(ctx,
 		"SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1 AND active_pid IS NOT NULL)",
@@ -92,29 +110,43 @@ func (r *ReplicationSlotAdvanceFromCTS) Create(ctx context.Context) error {
 		return nil
 	}
 
-	// Compare and advance atomically in a single query, matching the
-	// control-plane's CTE pattern. This handles NULL confirmed_flush_lsn
-	// on freshly created slots and avoids a TOCTOU race.
-	var newLSN string
-	err = r.conn.QueryRow(ctx, `
+	// Read current slot position. Skip if target is at or before current
+	// (slots never go backwards, so this is safe without a transaction).
+	var currentLSN string
+	err = r.conn.QueryRow(ctx,
+		"SELECT restart_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
+		slotName,
+	).Scan(&currentLSN)
+	if err != nil {
+		return fmt.Errorf("read current slot lsn %s: %w", slotName, err)
+	}
+	if targetLSN <= currentLSN {
+		slog.Info("slot already at or beyond target, no advance needed",
+			"slot", slotName, "target", targetLSN, "current", currentLSN)
+		return nil
+	}
+
+	// Advance the slot.
+	_, err = r.conn.Exec(ctx, `
 		WITH current AS (
 			SELECT confirmed_flush_lsn
 			FROM pg_replication_slots
 			WHERE slot_name = $1
 		)
 		SELECT CASE
-			WHEN $2::pg_lsn > COALESCE(confirmed_flush_lsn, '0/0'::pg_lsn)
+			WHEN $2::pg_lsn > confirmed_flush_lsn
 			THEN (pg_replication_slot_advance($1, $2::pg_lsn)).end_lsn
 			ELSE confirmed_flush_lsn
 		END AS new_lsn
 		FROM current`,
 		slotName, targetLSN,
-	).Scan(&newLSN)
+	)
 	if err != nil {
 		return fmt.Errorf("advance slot %s to %s: %w", slotName, targetLSN, err)
 	}
 
-	slog.Info("advanced replication slot", "slot", slotName, "to", newLSN)
+	r.AdvancedToLSN = targetLSN
+	slog.Info("advanced replication slot", "slot", slotName, "to", targetLSN)
 	return nil
 }
 

--- a/internal/spock/spock_test.go
+++ b/internal/spock/spock_test.go
@@ -521,16 +521,17 @@ func TestComputeDesiredPopulateThreeNodeAdd(t *testing.T) {
 		t.Error("sub_n1_n3 should have sync=true")
 	}
 
-	// Peer→new end-state subscription (sub_n2_n3) should depend on slot advance
+	// Peer→new end-state subscription (sub_n2_n3) gates on origin advance
+	// (which transitively depends on slot advance).
 	subN2N3 := mustSubscription(t, resources, "sub_n2_n3")
 	foundAdvance := false
 	for _, d := range subN2N3.Dependencies() {
-		if d.Type == ResourceTypeReplicationSlotAdvanceFromCTS {
+		if d.Type == ResourceTypeReplicationOriginAdvance {
 			foundAdvance = true
 		}
 	}
 	if !foundAdvance {
-		t.Error("sub_n2_n3 should depend on replication_slot_advance_from_cts")
+		t.Error("sub_n2_n3 should depend on replication_origin_advance")
 	}
 
 	// New→existing subs should depend on WaitForSyncEvent(source→new)
@@ -610,4 +611,175 @@ func mustSubscription(t *testing.T, resources map[resource.Identifier]resource.R
 		t.Fatalf("subscription %s has type %T, want *Subscription", id, r)
 	}
 	return s
+}
+
+// --- ReplicationOriginAdvance tests ---
+
+func TestReplicationOriginAdvanceIdentifier(t *testing.T) {
+	r := NewReplicationOriginAdvance("n2", "n3", "app", nil, nil)
+	id := r.Identifier()
+	if id.Type != ResourceTypeReplicationOriginAdvance {
+		t.Errorf("type: got %q, want %q", id.Type, ResourceTypeReplicationOriginAdvance)
+	}
+	if id.ID != "n2_n3" {
+		t.Errorf("id: got %q, want n2_n3", id.ID)
+	}
+}
+
+func TestReplicationOriginAdvanceDependsOnSlotAdvance(t *testing.T) {
+	slotAdv := &ReplicationSlotAdvanceFromCTS{providerName: "n2", subscriberName: "n3"}
+	r := NewReplicationOriginAdvance("n2", "n3", "app", slotAdv, nil)
+	deps := r.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d: %v", len(deps), deps)
+	}
+	if deps[0].Type != ResourceTypeReplicationSlotAdvanceFromCTS || deps[0].ID != "n2_n3" {
+		t.Errorf("expected dep on replication_slot_advance_from_cts/n2_n3, got %v", deps[0])
+	}
+}
+
+func TestReplicationOriginAdvanceEphemeral(t *testing.T) {
+	r := NewReplicationOriginAdvance("n2", "n3", "app", nil, nil)
+	if r.Status().Exists {
+		t.Error("ephemeral resource should not exist")
+	}
+}
+
+// --- PeerCatchup tests ---
+
+func TestPeerCatchupIdentifier(t *testing.T) {
+	syncEvt := &SyncEvent{providerName: "n2", subscriberName: "n1"}
+	r := NewPeerCatchup("n2", "n1", syncEvt, nil)
+	id := r.Identifier()
+	if id.Type != ResourceTypePeerCatchup {
+		t.Errorf("type: got %q, want %q", id.Type, ResourceTypePeerCatchup)
+	}
+	if id.ID != "n2_n1" {
+		t.Errorf("id: got %q, want n2_n1", id.ID)
+	}
+}
+
+func TestPeerCatchupDependsOnSyncEvent(t *testing.T) {
+	syncEvt := &SyncEvent{providerName: "n2", subscriberName: "n1"}
+	r := NewPeerCatchup("n2", "n1", syncEvt, nil)
+	deps := r.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d: %v", len(deps), deps)
+	}
+	if deps[0].Type != ResourceTypeSyncEvent || deps[0].ID != "n2_n1" {
+		t.Errorf("expected dep on sync_event/n2_n1, got %v", deps[0])
+	}
+}
+
+func TestPeerCatchupEphemeral(t *testing.T) {
+	r := NewPeerCatchup("n2", "n1", nil, nil)
+	if r.Status().Exists {
+		t.Error("ephemeral resource should not exist")
+	}
+}
+
+var _ resource.Resource = (*PeerCatchup)(nil)
+
+var _ resource.Resource = (*ReplicationOriginAdvance)(nil)
+
+// --- ComputeDesired populate hardening tests (CP PR #385) ---
+
+func TestComputeDesiredPopulateIncludesPeerCatchup(t *testing.T) {
+	cfg := &config.Config{
+		DBName: "app", AdminUser: "admin", PgEdgeUser: "pgedge",
+		Nodes: []config.Node{
+			{Name: "n1", Hostname: "h1"},
+			{Name: "n2", Hostname: "h2"},
+			{Name: "n3", Hostname: "h3", Bootstrap: config.NodeBootstrap{Mode: "spock", SourceNode: "n1"}},
+		},
+	}
+	conns := map[string]*pgxpool.Pool{"n1": nil, "n2": nil, "n3": nil}
+	resources := ComputeDesired(cfg, conns)
+
+	// PeerCatchup(peer=n2, source=n1) — id is "n2_n1".
+	assertResource(t, resources, ResourceTypePeerCatchup, "n2_n1")
+}
+
+func TestComputeDesiredPopulateIncludesOriginAdvance(t *testing.T) {
+	cfg := &config.Config{
+		DBName: "app", AdminUser: "admin", PgEdgeUser: "pgedge",
+		Nodes: []config.Node{
+			{Name: "n1", Hostname: "h1"},
+			{Name: "n2", Hostname: "h2"},
+			{Name: "n3", Hostname: "h3", Bootstrap: config.NodeBootstrap{Mode: "spock", SourceNode: "n1"}},
+		},
+	}
+	conns := map[string]*pgxpool.Pool{"n1": nil, "n2": nil, "n3": nil}
+	resources := ComputeDesired(cfg, conns)
+
+	// One OriginAdvance per (peer, new) pair. Only peer is n2 here.
+	assertResource(t, resources, ResourceTypeReplicationOriginAdvance, "n2_n3")
+}
+
+func TestComputeDesiredSourceSubscriptionWaitsOnPeerCatchup(t *testing.T) {
+	cfg := &config.Config{
+		DBName: "app", AdminUser: "admin", PgEdgeUser: "pgedge",
+		Nodes: []config.Node{
+			{Name: "n1", Hostname: "h1"},
+			{Name: "n2", Hostname: "h2"},
+			{Name: "n3", Hostname: "h3", Bootstrap: config.NodeBootstrap{Mode: "spock", SourceNode: "n1"}},
+		},
+	}
+	conns := map[string]*pgxpool.Pool{"n1": nil, "n2": nil, "n3": nil}
+	resources := ComputeDesired(cfg, conns)
+
+	// Source→new subscription (sub_n1_n3) must depend on PeerCatchup(n2_n1)
+	// AND on WaitForSyncEvent(n2_n1). The first proves apply-progress
+	// caught up; the second proves the bookmark landed.
+	sub := mustSubscription(t, resources, "sub_n1_n3")
+	var foundCatchup, foundWait bool
+	for _, d := range sub.Dependencies() {
+		if d.Type == ResourceTypePeerCatchup && d.ID == "n2_n1" {
+			foundCatchup = true
+		}
+		if d.Type == ResourceTypeWaitForSyncEvent && d.ID == "n2_n1" {
+			foundWait = true
+		}
+	}
+	if !foundCatchup {
+		t.Error("sub_n1_n3 should depend on peer_catchup/n2_n1")
+	}
+	if !foundWait {
+		t.Error("sub_n1_n3 should depend on wait_for_sync_event/n2_n1")
+	}
+}
+
+func TestComputeDesiredPeerSubscriptionWaitsOnOriginAdvance(t *testing.T) {
+	cfg := &config.Config{
+		DBName: "app", AdminUser: "admin", PgEdgeUser: "pgedge",
+		Nodes: []config.Node{
+			{Name: "n1", Hostname: "h1"},
+			{Name: "n2", Hostname: "h2"},
+			{Name: "n3", Hostname: "h3", Bootstrap: config.NodeBootstrap{Mode: "spock", SourceNode: "n1"}},
+		},
+	}
+	conns := map[string]*pgxpool.Pool{"n1": nil, "n2": nil, "n3": nil}
+	resources := ComputeDesired(cfg, conns)
+
+	// Peer→new end-state subscription (sub_n2_n3) should now depend on
+	// ReplicationOriginAdvance (which itself depends on slot advance,
+	// so slot advance still runs first). It must NOT directly depend on
+	// ReplicationSlotAdvanceFromCTS anymore — that dep moved to OriginAdvance.
+	sub := mustSubscription(t, resources, "sub_n2_n3")
+	var foundOrigin bool
+	var foundSlotAdvanceDirect bool
+	for _, d := range sub.Dependencies() {
+		if d.Type == ResourceTypeReplicationOriginAdvance && d.ID == "n2_n3" {
+			foundOrigin = true
+		}
+		if d.Type == ResourceTypeReplicationSlotAdvanceFromCTS {
+			foundSlotAdvanceDirect = true
+		}
+	}
+	if !foundOrigin {
+		t.Error("sub_n2_n3 should depend on replication_origin_advance/n2_n3")
+	}
+	if foundSlotAdvanceDirect {
+		t.Error("sub_n2_n3 should NOT directly depend on replication_slot_advance_from_cts (gated via OriginAdvance instead)")
+	}
 }

--- a/internal/spock/spock_test.go
+++ b/internal/spock/spock_test.go
@@ -526,12 +526,12 @@ func TestComputeDesiredPopulateThreeNodeAdd(t *testing.T) {
 	subN2N3 := mustSubscription(t, resources, "sub_n2_n3")
 	foundAdvance := false
 	for _, d := range subN2N3.Dependencies() {
-		if d.Type == ResourceTypeReplicationOriginAdvance {
+		if d.Type == ResourceTypeReplicationOriginAdvance && d.ID == "n2_n3" {
 			foundAdvance = true
 		}
 	}
 	if !foundAdvance {
-		t.Error("sub_n2_n3 should depend on replication_origin_advance")
+		t.Error("sub_n2_n3 should depend on replication_origin_advance/n2_n3")
 	}
 
 	// New→existing subs should depend on WaitForSyncEvent(source→new)

--- a/internal/spock/wait_for_sync_event.go
+++ b/internal/spock/wait_for_sync_event.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -17,6 +18,12 @@ const (
 
 // WaitForSyncEvent polls on the subscriber until it receives the sync event
 // from the provider. Reads the LSN from the paired SyncEvent via struct pointer.
+//
+// Transient subscription states (disabled, down) trigger backoff polling
+// rather than immediate failure — the apply worker may not have started yet
+// during add-node. Unknown subscription states are treated as errors
+// (fail-closed default).
+//
 // Ephemeral resource — re-executes every run.
 type WaitForSyncEvent struct {
 	providerName   string
@@ -80,7 +87,19 @@ func (r *WaitForSyncEvent) Create(ctx context.Context) error {
 			// Don't fail — status query might not work during initialization
 		} else {
 			switch status {
+			case "initializing", "replicating", "unknown":
+				// Worker is running — fall through to wait_for_sync_event call.
 			case "disabled", "down":
+				// Worker not yet started — transient during add-node. Sleep
+				// before next iteration to avoid busy-looping while the
+				// worker comes up.
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(syncEventTimeout * time.Second):
+				}
+				continue
+			default:
 				return fmt.Errorf("subscription has unhealthy status %q: provider=%s subscriber=%s",
 					status, r.providerName, r.subscriberName)
 			}

--- a/test/Makefile
+++ b/test/Makefile
@@ -92,6 +92,11 @@ test-reset: kind-load-image
 	cd $(root_dir) && go test -tags integration -v -timeout 30m \
 		-run "TestResetSpock" ./test/integration/...
 
+.PHONY: test-failover
+test-failover: kind-load-image
+	cd $(root_dir) && go test -tags integration -v -timeout 30m \
+		-run "TestUnplannedFailover" ./test/integration/...
+
 # ---- All ----
 
 .PHONY: test-all

--- a/test/integration/failover_helpers.go
+++ b/test/integration/failover_helpers.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pgEdge/pgedge-helm/test/pkg/kube"
+	"github.com/pgEdge/pgedge-helm/test/pkg/wait"
+)
+
+// getPrimaryPod returns the pod name of the current primary for the given
+// CNPG cluster, identified via the cnpg.io/instanceRole=primary label.
+func getPrimaryPod(k *kube.Kubectl, cluster string) (string, error) {
+	args := []string{}
+	if k.Context != "" {
+		args = append(args, "--context", k.Context)
+	}
+	if k.Namespace != "" {
+		args = append(args, "-n", k.Namespace)
+	}
+	args = append(args,
+		"get", "pod",
+		"-l", fmt.Sprintf("cnpg.io/cluster=%s,cnpg.io/instanceRole=primary", cluster),
+		"-o", "jsonpath={.items[0].metadata.name}",
+	)
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("get primary pod for %s: %w (%s)", cluster, err, string(out))
+	}
+	name := strings.TrimSpace(string(out))
+	if name == "" {
+		return "", fmt.Errorf("no primary pod found for cluster %s", cluster)
+	}
+	return name, nil
+}
+
+// killPrimary force-deletes the current primary pod of the given cluster.
+// CNPG will promote a standby in response. Returns the name of the killed pod.
+func killPrimary(t *testing.T, k *kube.Kubectl, cluster string) string {
+	t.Helper()
+	primary, err := getPrimaryPod(k, cluster)
+	if err != nil {
+		t.Fatalf("locate primary for %s: %v", cluster, err)
+	}
+
+	args := []string{}
+	if k.Context != "" {
+		args = append(args, "--context", k.Context)
+	}
+	if k.Namespace != "" {
+		args = append(args, "-n", k.Namespace)
+	}
+	args = append(args, "delete", "pod", primary,
+		"--grace-period=0", "--force", "--wait=false")
+
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("kill primary %s: %v (%s)", primary, err, string(out))
+	}
+	t.Logf("force-deleted primary pod %s", primary)
+	return primary
+}
+
+// waitForStandbySlotSync blocks until each given standby pod has at least
+// one logical spk_* slot in pg_replication_slots. Spock's failover_slots
+// worker syncs logical slots from primary to standby on an interval (~60s).
+// Without this wait, a primary kill that happens before the first sync will
+// promote a standby that has no Spock slot, breaking replication.
+func waitForStandbySlotSync(t *testing.T, k *kube.Kubectl, standbyPods []string, timeout time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for _, pod := range standbyPods {
+		pod := pod
+		err := wait.Until(ctx, 5*time.Second, func() (bool, error) {
+			out, err := k.ExecSQL(pod,
+				"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical' AND slot_name LIKE 'spk_%';")
+			if err != nil {
+				return false, nil
+			}
+			return strings.TrimSpace(out) != "0", nil
+		})
+		if err != nil {
+			out, _ := k.ExecSQL(pod,
+				"SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical';")
+			t.Fatalf("standby %s never received a logical spk_* slot: %v (slots present: %q)",
+				pod, err, strings.TrimSpace(out))
+		}
+		t.Logf("standby %s has logical spk_* slot synced", pod)
+	}
+}
+
+// waitForPromotion blocks until CNPG promotes a new primary for the cluster
+// (different from oldPrimary) and that new primary is Ready.
+func waitForPromotion(t *testing.T, k *kube.Kubectl, cluster, oldPrimary string, timeout time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var newPrimary string
+	err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+		p, err := getPrimaryPod(k, cluster)
+		if err != nil {
+			// Transient — primary may not yet be elected.
+			return false, nil
+		}
+		if p == oldPrimary {
+			return false, nil
+		}
+		newPrimary = p
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("waiting for promotion of %s: %v", cluster, err)
+	}
+	t.Logf("new primary elected: %s", newPrimary)
+
+	// Make sure the new primary's pod is Ready before tests query it.
+	if err := k.WaitForCondition("pod", newPrimary, "Ready", timeout.String()); err != nil {
+		t.Fatalf("new primary %s not Ready: %v", newPrimary, err)
+	}
+}

--- a/test/integration/failover_test.go
+++ b/test/integration/failover_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pgEdge/pgedge-helm/test/pkg/wait"
+)
+
+// TestUnplannedFailover verifies that an unplanned CNPG primary failure
+// (force-delete the primary pod) results in standby promotion and that
+// Spock replication survives in both directions with no data loss.
+func TestUnplannedFailover(t *testing.T) {
+	t.Cleanup(func() { uninstallChart(t) })
+	installChart(t, "distributed-2node-2instance-values.yaml")
+
+	for _, name := range []string{"pgedge-n1", "pgedge-n2"} {
+		if err := wait.ForClusterHealthy(testKube, name, timeout); err != nil {
+			t.Fatalf("cluster %s not healthy: %v", name, err)
+		}
+	}
+	if err := wait.ForJobComplete(testKube, "pgedge-init-spock", timeout); err != nil {
+		logs, _ := testKube.Logs("job/pgedge-init-spock")
+		t.Fatalf("init-spock job failed: %v\nlogs:\n%s", err, logs)
+	}
+
+	// Seed data on n1 and confirm it reaches n2 BEFORE we kill anything,
+	// so the no-data-loss assertion has a known baseline.
+	_, err := testKube.ExecSQL("pgedge-n1-1",
+		"CREATE TABLE test_failover (id int PRIMARY KEY, val text);")
+	if err != nil {
+		t.Fatalf("create test_failover: %v", err)
+	}
+	_, err = testKube.ExecSQL("pgedge-n1-1",
+		"INSERT INTO test_failover SELECT g, 'pre-failover' FROM generate_series(1, 100) g;")
+	if err != nil {
+		t.Fatalf("seed test_failover on n1: %v", err)
+	}
+
+	waitForReplication(t, []string{"pgedge-n1-1", "pgedge-n2-1"})
+
+	expectedCount, err := testKube.ExecSQL("pgedge-n2-1",
+		"SELECT count(*) FROM test_failover;")
+	if err != nil {
+		t.Fatalf("count test_failover on n2: %v", err)
+	}
+	expectedCount = strings.TrimSpace(expectedCount)
+	if expectedCount != "100" {
+		t.Fatalf("expected 100 rows on n2 before failover, got %s", expectedCount)
+	}
+
+	// Wait for Spock's failover_slots worker to sync logical slots from
+	// each primary to its standby. Without this, killing the primary before
+	// the worker's first successful sync leaves the promoted standby with no
+	// Spock slot, which breaks replication. The worker runs on an interval
+	// (~60s) so the first sync can take up to ~2 minutes from cluster init.
+	waitForStandbySlotSync(t, testKube,
+		[]string{"pgedge-n1-2", "pgedge-n2-2"}, 3*time.Minute)
+
+	oldPrimary := killPrimary(t, testKube, "pgedge-n1")
+	waitForPromotion(t, testKube, "pgedge-n1", oldPrimary, timeout)
+
+	// CNPG keeps the -rw service pointing at the current primary, so
+	// queries via the service auto-route to the new primary. But our
+	// test helpers exec directly into the pod by name. Re-resolve the
+	// primary pod name for subsequent queries.
+	newPrimary, err := getPrimaryPod(testKube, "pgedge-n1")
+	if err != nil {
+		t.Fatalf("locate new primary: %v", err)
+	}
+
+	t.Run("no_data_loss", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+			out, err := testKube.ExecSQL(newPrimary,
+				"SELECT count(*) FROM test_failover;")
+			if err != nil {
+				return false, nil
+			}
+			return strings.TrimSpace(out) == expectedCount, nil
+		})
+		if err != nil {
+			out, _ := testKube.ExecSQL(newPrimary,
+				"SELECT count(*) FROM test_failover;")
+			t.Errorf("new primary %s count != %s (got %q)", newPrimary, expectedCount, strings.TrimSpace(out))
+		}
+	})
+
+	t.Run("forward_replication", func(t *testing.T) {
+		// Insert on n2, expect to land on the new n1 primary.
+		_, err := testKube.ExecSQL("pgedge-n2-1",
+			"INSERT INTO test_failover VALUES (1001, 'from-n2-post-failover');")
+		if err != nil {
+			t.Fatalf("insert on n2: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		err = wait.Until(ctx, 2*time.Second, func() (bool, error) {
+			out, err := testKube.ExecSQL(newPrimary,
+				"SELECT val FROM test_failover WHERE id = 1001;")
+			if err != nil {
+				return false, nil
+			}
+			return strings.Contains(out, "from-n2-post-failover"), nil
+		})
+		if err != nil {
+			t.Error("row from n2 did not reach new n1 primary after failover")
+		}
+	})
+
+	t.Run("reverse_replication", func(t *testing.T) {
+		// Insert on the new n1 primary, expect to land on n2.
+		_, err := testKube.ExecSQL(newPrimary,
+			"INSERT INTO test_failover VALUES (1002, 'from-new-n1');")
+		if err != nil {
+			t.Fatalf("insert on new n1 primary %s: %v", newPrimary, err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		err = wait.Until(ctx, 2*time.Second, func() (bool, error) {
+			out, err := testKube.ExecSQL("pgedge-n2-1",
+				"SELECT val FROM test_failover WHERE id = 1002;")
+			if err != nil {
+				return false, nil
+			}
+			return strings.Contains(out, "from-new-n1"), nil
+		})
+		if err != nil {
+			t.Error("row from new n1 primary did not reach n2 after failover")
+		}
+	})
+
+	t.Run("subscriptions_healthy", func(t *testing.T) {
+		for _, tc := range []struct{ pod, label string }{
+			{newPrimary, "n1"},
+			{"pgedge-n2-1", "n2"},
+		} {
+			t.Run(tc.label, func(t *testing.T) {
+				out, err := testKube.ExecSQL(tc.pod,
+					"SELECT (spock.sub_show_status(sub_name)).status FROM spock.subscription;")
+				if err != nil {
+					t.Fatalf("sub status on %s: %v", tc.pod, err)
+				}
+				for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+					status := strings.TrimSpace(line)
+					if status != "replicating" && status != "initializing" {
+						t.Errorf("%s has subscription with bad status %q (full output: %q)",
+							tc.pod, status, out)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("slots_active", func(t *testing.T) {
+		for _, tc := range []struct{ pod, label string }{
+			{newPrimary, "n1"},
+			{"pgedge-n2-1", "n2"},
+		} {
+			t.Run(tc.label, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				defer cancel()
+				err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+					out, err := testKube.ExecSQL(tc.pod, `
+						SELECT count(*) FROM pg_replication_slots
+						WHERE slot_type = 'logical' AND slot_name LIKE 'spk_%' AND active;`)
+					if err != nil {
+						return false, nil
+					}
+					return strings.TrimSpace(out) == "1", nil
+				})
+				if err != nil {
+					out, _ := testKube.ExecSQL(tc.pod,
+						"SELECT slot_name, active FROM pg_replication_slots WHERE slot_type = 'logical' AND slot_name LIKE 'spk_%';")
+					t.Errorf("%s has inactive spk_* slot(s): %s", tc.pod, strings.TrimSpace(out))
+				}
+			})
+		}
+	})
+
+	t.Run("full_mesh_reoplication", func(t *testing.T) {
+		verifyMeshReplication(t, "test_failover",
+			[]string{newPrimary, "pgedge-n2-1"}, 2001)
+	})
+}

--- a/test/integration/nodes_test.go
+++ b/test/integration/nodes_test.go
@@ -91,44 +91,8 @@ func TestNodesAddNode(t *testing.T) {
 	})
 
 	t.Run("full_mesh_replication", func(t *testing.T) {
-		// Insert a row on each node and verify it reaches all others
-		writes := map[string]int{
-			"pgedge-n1-1": 10,
-			"pgedge-n2-1": 11,
-			"pgedge-n3-1": 12,
-		}
-		for pod, id := range writes {
-			_, err := testKube.ExecSQL(pod,
-				fmt.Sprintf("INSERT INTO test_add_node VALUES (%d, 'from-%s');", id, pod))
-			if err != nil {
-				t.Fatalf("failed to insert on %s: %v", pod, err)
-			}
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
-
-		for srcPod, id := range writes {
-			for _, dstPod := range []string{"pgedge-n1-1", "pgedge-n2-1", "pgedge-n3-1"} {
-				if dstPod == srcPod {
-					continue
-				}
-				t.Run(fmt.Sprintf("%s_to_%s", srcPod, dstPod), func(t *testing.T) {
-					expected := fmt.Sprintf("from-%s", srcPod)
-					err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
-						out, err := testKube.ExecSQL(dstPod,
-							fmt.Sprintf("SELECT val FROM test_add_node WHERE id = %d;", id))
-						if err != nil {
-							return false, nil
-						}
-						return strings.Contains(out, expected), nil
-					})
-					if err != nil {
-						t.Errorf("data from %s (id=%d) did not replicate to %s", srcPod, id, dstPod)
-					}
-				})
-			}
-		}
+		verifyMeshReplication(t, "test_add_node",
+			[]string{"pgedge-n1-1", "pgedge-n2-1", "pgedge-n3-1"}, 10)
 	})
 
 	t.Run("idempotent_rerun_on_3_nodes", func(t *testing.T) {
@@ -281,6 +245,30 @@ func TestNodesAddNodeZeroDowntime(t *testing.T) {
 	// Confirm replication caught up after final writes
 	waitForReplication(t, allPods)
 
+	t.Run("origin_advanced_on_n3", func(t *testing.T) {
+		// Each peer slot has a corresponding spk_* origin on n3. Assert
+		// pg_replication_origin_progress is non-zero. A zeroed origin
+		// causes the apply worker on a CNPG-promoted standby to replay
+		// historical WAL from 0/0, producing duplicate-key errors.
+		// Enumerate by spk_* prefix to avoid hard-coding the database name.
+		out, err := testKube.ExecSQL("pgedge-n3-1", `
+			SELECT roname || '=' || pg_replication_origin_progress(roname, false)::text
+			FROM pg_replication_origin
+			WHERE roname LIKE 'spk_%';`)
+		if err != nil {
+			t.Fatalf("query origin progress: %v", err)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) < 2 {
+			t.Fatalf("expected at least 2 spk_* origins on n3 (one per peer), got: %q", out)
+		}
+		for _, line := range lines {
+			if strings.HasSuffix(line, "=0/0") {
+				t.Errorf("origin at 0/0 on n3: %s — OriginAdvance did not advance", line)
+			}
+		}
+	})
+
 	t.Run("n3_has_all_data", func(t *testing.T) {
 		// All replication paths confirmed caught up — counts must match
 		for _, table := range []string{"test_zdt_n1", "test_zdt_n2"} {
@@ -344,51 +332,6 @@ func TestNodesAddNodeZeroDowntime(t *testing.T) {
 			})
 		}
 	})
-}
-
-// waitForReplication fires a sync event on each pod and waits for every other
-// pod to receive it, confirming all replication paths have caught up.
-// Matches the Control Plane's WaitForReplication pattern.
-func waitForReplication(t *testing.T, pods []string) {
-	t.Helper()
-
-	type syncEvt struct {
-		provider string
-		lsn      string
-	}
-
-	var events []syncEvt
-	for _, pod := range pods {
-		lsn, err := testKube.ExecSQL(pod, "SELECT spock.sync_event();")
-		if err != nil {
-			t.Fatalf("sync_event on %s: %v", pod, err)
-		}
-		events = append(events, syncEvt{podToNode(pod), strings.TrimSpace(lsn)})
-	}
-
-	for _, evt := range events {
-		for _, dst := range pods {
-			if podToNode(dst) == evt.provider {
-				continue
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-			err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
-				_, err := testKube.ExecSQL(dst,
-					fmt.Sprintf("CALL spock.wait_for_sync_event(true, '%s', '%s'::pg_lsn, 10);",
-						evt.provider, evt.lsn))
-				return err == nil, nil
-			})
-			cancel()
-			if err != nil {
-				t.Fatalf("%s did not receive sync event from %s (lsn=%s)", dst, evt.provider, evt.lsn)
-			}
-		}
-	}
-}
-
-// podToNode extracts the node name from a pod name (e.g. "pgedge-n1-1" -> "n1").
-func podToNode(pod string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(pod, "pgedge-"), "-1")
 }
 
 func TestNodesRemoveNode(t *testing.T) {

--- a/test/integration/replication_helpers_test.go
+++ b/test/integration/replication_helpers_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pgEdge/pgedge-helm/test/pkg/wait"
+)
+
+// waitForReplication fires a sync event on each pod and waits for every other
+// pod to receive it, confirming all replication paths have caught up.
+// Matches the Control Plane's WaitForReplication pattern.
+func waitForReplication(t *testing.T, pods []string) {
+	t.Helper()
+
+	type syncEvt struct {
+		provider string
+		lsn      string
+	}
+
+	var events []syncEvt
+	for _, pod := range pods {
+		lsn, err := testKube.ExecSQL(pod, "SELECT spock.sync_event();")
+		if err != nil {
+			t.Fatalf("sync_event on %s: %v", pod, err)
+		}
+		events = append(events, syncEvt{podToNode(pod), strings.TrimSpace(lsn)})
+	}
+
+	for _, evt := range events {
+		for _, dst := range pods {
+			if podToNode(dst) == evt.provider {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+				_, err := testKube.ExecSQL(dst,
+					fmt.Sprintf("CALL spock.wait_for_sync_event(true, '%s', '%s'::pg_lsn, 10);",
+						evt.provider, evt.lsn))
+				return err == nil, nil
+			})
+			cancel()
+			if err != nil {
+				t.Fatalf("%s did not receive sync event from %s (lsn=%s)", dst, evt.provider, evt.lsn)
+			}
+		}
+	}
+}
+
+// verifyMeshReplication writes one row per pod into the given (int id, text val)
+// table, then verifies each row replicates to every other pod. baseID is the
+// first integer used; subsequent pods get baseID+1, baseID+2, ... Callers
+// must ensure that range doesn't collide with rows already in the table.
+// Each (src, dst) pair runs as its own t.Run sub-test for clear failure output.
+func verifyMeshReplication(t *testing.T, table string, pods []string, baseID int) {
+	t.Helper()
+
+	writes := map[string]int{}
+	for i, pod := range pods {
+		writes[pod] = baseID + i
+	}
+
+	for pod, id := range writes {
+		_, err := testKube.ExecSQL(pod,
+			fmt.Sprintf("INSERT INTO %s VALUES (%d, 'from-%s');", table, id, pod))
+		if err != nil {
+			t.Fatalf("failed to insert on %s: %v", pod, err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	for srcPod, id := range writes {
+		for _, dstPod := range pods {
+			if dstPod == srcPod {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s_to_%s", srcPod, dstPod), func(t *testing.T) {
+				expected := fmt.Sprintf("from-%s", srcPod)
+				err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
+					out, err := testKube.ExecSQL(dstPod,
+						fmt.Sprintf("SELECT val FROM %s WHERE id = %d;", table, id))
+					if err != nil {
+						return false, nil
+					}
+					return strings.Contains(out, expected), nil
+				})
+				if err != nil {
+					t.Errorf("data from %s (id=%d) did not replicate to %s", srcPod, id, dstPod)
+				}
+			})
+		}
+	}
+}
+
+// podToNode extracts the node name from a pod name (e.g. "pgedge-n1-1" -> "n1").
+func podToNode(pod string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(pod, "pgedge-"), "-1")
+}

--- a/test/integration/replication_helpers_test.go
+++ b/test/integration/replication_helpers_test.go
@@ -73,15 +73,14 @@ func verifyMeshReplication(t *testing.T, table string, pods []string, baseID int
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	for srcPod, id := range writes {
 		for _, dstPod := range pods {
 			if dstPod == srcPod {
 				continue
 			}
 			t.Run(fmt.Sprintf("%s_to_%s", srcPod, dstPod), func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				defer cancel()
 				expected := fmt.Sprintf("from-%s", srcPod)
 				err := wait.Until(ctx, 2*time.Second, func() (bool, error) {
 					out, err := testKube.ExecSQL(dstPod,

--- a/test/integration/testdata/distributed-2node-2instance-values.yaml
+++ b/test/integration/testdata/distributed-2node-2instance-values.yaml
@@ -1,0 +1,11 @@
+pgEdge:
+  appName: pgedge
+  nodes:
+    - name: n1
+      hostname: pgedge-n1-rw
+    - name: n2
+      hostname: pgedge-n2-rw
+  clusterSpec:
+    instances: 2
+    storage:
+      size: 1Gi


### PR DESCRIPTION
This PR hardens the zero-downtime add-node populate flow with `PeerCatchup`, `ReplicationOriginAdvance`, and a `WaitForSyncEvent` fix that aligns with recent updates in the Control Plane project: https://github.com/pgEdge/control-plane/pull/385. 

In addition, it adds `TestUnplannedFailover` and an `origin_advanced_on_n3` assertion to the existing zero-downtime add-node test to improve integration test coverage.

Each commit can be reviewed independently.