### PR TITLE
fix(init-spock): route admin DB pool through internalHostname when set

### DIFF
--- a/changes/unreleased/Fixed-20260520-160951.yaml
+++ b/changes/unreleased/Fixed-20260520-160951.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed init-spock admin connection pool to honor internalHostname for cluster-local routing, matching the existing health check behavior
+time: 2026-05-20T16:09:51.217497-05:00

--- a/cmd/init-spock/main.go
+++ b/cmd/init-spock/main.go
@@ -71,7 +71,7 @@ func run(ctx context.Context) error {
 		if err := pg.WaitReady(ctx, node.Hostname, node.InternalHostname, cfg.DBName, cfg.AdminUser); err != nil {
 			return err
 		}
-		pool, err := pg.ConnectPool(ctx, node.Hostname, cfg.DBName, cfg.AdminUser)
+		pool, err := pg.ConnectPool(ctx, node.Hostname, node.InternalHostname, cfg.DBName, cfg.AdminUser)
 		if err != nil {
 			return err
 		}

--- a/internal/pg/pg.go
+++ b/internal/pg/pg.go
@@ -62,10 +62,10 @@ func Connect(ctx context.Context, host, dbName, user string) (*pgx.Conn, error) 
 	return pgx.ConnectConfig(ctx, cfg)
 }
 
-// ConnectPool creates a new pgxpool connection pool to the given host.
-// The pool is safe for concurrent use from multiple goroutines.
-func ConnectPool(ctx context.Context, host, dbName, user string) (*pgxpool.Pool, error) {
-	connCfg, err := buildConnConfig(host, dbName, user, defaultCertPath, defaultKeyPath)
+// buildPoolConfig creates a pgxpool config, preferring internalHostname when set.
+func buildPoolConfig(hostname, internalHostname, dbName, user, certPath, keyPath string) (*pgxpool.Config, error) {
+	host := connectHost(hostname, internalHostname)
+	connCfg, err := buildConnConfig(host, dbName, user, certPath, keyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -74,6 +74,17 @@ func ConnectPool(ctx context.Context, host, dbName, user string) (*pgxpool.Pool,
 		return nil, fmt.Errorf("parse pool config: %w", err)
 	}
 	poolCfg.ConnConfig = connCfg
+	return poolCfg, nil
+}
+
+// ConnectPool creates a new pgxpool connection pool to the node.
+// Uses internalHostname if set, otherwise falls back to hostname.
+// The pool is safe for concurrent use from multiple goroutines.
+func ConnectPool(ctx context.Context, hostname, internalHostname, dbName, user string) (*pgxpool.Pool, error) {
+	poolCfg, err := buildPoolConfig(hostname, internalHostname, dbName, user, defaultCertPath, defaultKeyPath)
+	if err != nil {
+		return nil, err
+	}
 	return pgxpool.NewWithConfig(ctx, poolCfg)
 }
 

--- a/internal/pg/pg_test.go
+++ b/internal/pg/pg_test.go
@@ -58,6 +58,32 @@ func TestConnectHost(t *testing.T) {
 	}
 }
 
+func TestBuildPoolConfigPrefersInternalHostname(t *testing.T) {
+	certPath, keyPath := generateTempCerts(t)
+
+	cfg, err := buildPoolConfig("external.example.com", "pgedge-n1-rw",
+		"app", "admin", certPath, keyPath)
+	if err != nil {
+		t.Fatalf("buildPoolConfig: %v", err)
+	}
+	if cfg.ConnConfig.Host != "pgedge-n1-rw" {
+		t.Errorf("Host: got %q, want internalHostname pgedge-n1-rw", cfg.ConnConfig.Host)
+	}
+}
+
+func TestBuildPoolConfigFallsBackToHostname(t *testing.T) {
+	certPath, keyPath := generateTempCerts(t)
+
+	cfg, err := buildPoolConfig("external.example.com", "",
+		"app", "admin", certPath, keyPath)
+	if err != nil {
+		t.Fatalf("buildPoolConfig: %v", err)
+	}
+	if cfg.ConnConfig.Host != "external.example.com" {
+		t.Errorf("Host: got %q, want hostname external.example.com", cfg.ConnConfig.Host)
+	}
+}
+
 // generateTempCerts creates a temporary self-signed certificate and key for testing.
 func generateTempCerts(t *testing.T) (certPath, keyPath string) {
 	t.Helper()


### PR DESCRIPTION
ConnectPool previously only accepted hostname, so admin SQL traffic (spock setup, reset, and reconcile) routed through the external hostname / TLSRoute even when internalHostname was configured for cluster-local connectivity. The readiness check already preferred internalHostname; this brings the pool used for actual configuration in line with it.

Extracts buildPoolConfig to mirror buildConnConfig, adds unit tests covering both prefer-internal and fallback-to-hostname paths.