### PR TITLE
build(release): bump version to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to pgEdge Helm will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0 - 2026-05-22
+
+### Added
+
+- Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous behavior which required stopping writes during `helm upgrade` (#52)
+- Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
+- Added the ability to configure the database name, owner, and admin role via Helm values (`initdb.database`, `initdb.owner`, `pgEdge.adminUser`). Also added documentation covering all managed users, their authentication methods, and how to create additional users or disable passwords (#54)
+
+### Changed
+
+- Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined, copy-paste-and-go guide that assumes a working cluster (#46)
+- Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release (#51)
+- Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired state. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
+
+### Fixed
+
+- Fixed init-spock admin connection pool to honor internalHostname for cluster-local routing, matching the existing health check behavior
+
 ## v0.2.0 - 2026-02-11
 
 ### Added
@@ -23,8 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed duplicate `privateKey` key in client-ca Certificate resource
-
-
 ## v0.1.0 - 2025-12-19
 
 ### Added

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,4 +9,4 @@ sources:
 maintainers:
   - name: pgEdge
     url: https://github.com/pgEdge
-version: 0.2.0
+version: 1.0.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The **pgEdge Helm** chart supports deploying both pgEdge Enterprise Postgres and
 
 This chart leverages [CloudNativePG](https://cloudnative-pg.io/) to manage Postgres, providing flexible options for single-region and multi-region deployments.
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
 
 ## Features
 

--- a/changes/unreleased/Added-20260416-155002.yaml
+++ b/changes/unreleased/Added-20260416-155002.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous behavior which required stopping writes during `helm upgrade` (#52)
-time: 2026-04-16T15:50:02.825165-05:00

--- a/changes/unreleased/Added-20260416-155011.yaml
+++ b/changes/unreleased/Added-20260416-155011.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
-time: 2026-04-16T15:50:11.305881-05:00

--- a/changes/unreleased/Added-20260416-155036.yaml
+++ b/changes/unreleased/Added-20260416-155036.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: Added the ability to configure the database name, owner, and admin role via Helm values (`initdb.database`, `initdb.owner`, `pgEdge.adminUser`). Also added documentation covering all managed users, their authentication methods, and how to create additional users or disable passwords (#54)
-time: 2026-04-16T15:50:36.735527-05:00

--- a/changes/unreleased/Changed-20260416-155011.yaml
+++ b/changes/unreleased/Changed-20260416-155011.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined, copy-paste-and-go guide that assumes a working cluster (#46)
-time: 2026-04-16T15:50:11.328-05:00

--- a/changes/unreleased/Changed-20260416-155041.yaml
+++ b/changes/unreleased/Changed-20260416-155041.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release (#51)
-time: 2026-04-16T15:50:41.16161-05:00

--- a/changes/unreleased/Changed-20260416-155044.yaml
+++ b/changes/unreleased/Changed-20260416-155044.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired state. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
-time: 2026-04-16T15:50:44.776041-05:00

--- a/changes/unreleased/Fixed-20260520-160951.yaml
+++ b/changes/unreleased/Fixed-20260520-160951.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Fixed init-spock admin connection pool to honor internalHostname for cluster-local routing, matching the existing health check behavior
-time: 2026-05-20T16:09:51.217497-05:00

--- a/changes/v1.0.0.md
+++ b/changes/v1.0.0.md
@@ -1,0 +1,17 @@
+## v1.0.0 - 2026-05-22
+
+### Added
+
+- Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous behavior which required stopping writes during `helm upgrade` (#52)
+- Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
+- Added the ability to configure the database name, owner, and admin role via Helm values (`initdb.database`, `initdb.owner`, `pgEdge.adminUser`). Also added documentation covering all managed users, their authentication methods, and how to create additional users or disable passwords (#54)
+
+### Changed
+
+- Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined, copy-paste-and-go guide that assumes a working cluster (#46)
+- Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release (#51)
+- Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired state. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
+
+### Fixed
+
+- Fixed init-spock admin connection pool to honor internalHostname for cluster-local routing, matching the existing health check behavior

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@ All notable changes to pgEdge Helm will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0 - 2026-05-22
+
+### Added
+
+- Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous behavior which required stopping writes during `helm upgrade` (#52)
+- Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
+- Added the ability to configure the database name, owner, and admin role via Helm values (`initdb.database`, `initdb.owner`, `pgEdge.adminUser`). Also added documentation covering all managed users, their authentication methods, and how to create additional users or disable passwords (#54)
+
+### Changed
+
+- Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined, copy-paste-and-go guide that assumes a working cluster (#46)
+- Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release (#51)
+- Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired state. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)
+
+### Fixed
+
+- Fixed init-spock admin connection pool to honor internalHostname for cluster-local routing, matching the existing health check behavior
+
 ## v0.2.0 - 2026-02-11
 
 ### Added
@@ -23,8 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed duplicate `privateKey` key in client-ca Certificate resource
-
-
 ## v0.1.0 - 2025-12-19
 
 ### Added

--- a/test/unit/helpers.go
+++ b/test/unit/helpers.go
@@ -3,6 +3,7 @@
 package unit
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -25,6 +26,22 @@ func testdataPath(t *testing.T, name string) string {
 	t.Helper()
 	_, filename, _, _ := runtime.Caller(0)
 	return filepath.Join(filepath.Dir(filename), "testdata", name)
+}
+
+// chartVersion returns the version field from Chart.yaml.
+func chartVersion(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(chartPath(t), "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read Chart.yaml: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "version:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "version:"))
+		}
+	}
+	t.Fatal("version field not found in Chart.yaml")
+	return ""
 }
 
 // renderTemplate runs helm template with the given values file and returns parsed objects.

--- a/test/unit/job_test.go
+++ b/test/unit/job_test.go
@@ -53,7 +53,7 @@ func TestInitSpockJobDefaultImage(t *testing.T) {
 	}
 	container := containers[0].(map[string]interface{})
 	image, _, _ := unstructured.NestedString(container, "image")
-	expected := "ghcr.io/pgedge/pgedge-helm-utils:v0.2.0"
+	expected := "ghcr.io/pgedge/pgedge-helm-utils:v" + chartVersion(t)
 	if image != expected {
 		t.Errorf("expected default image %q, got %q", expected, image)
 	}


### PR DESCRIPTION
## v1.0.0 - 2026-05-22

### Added

- Added support for zero-downtime node addition using a Spock populate pipeline. Writes can continue uninterrupted on existing nodes while a new node syncs via logical replication, replacing the previous behavior which required stopping writes during `helm upgrade` (#52)
- Added a guided walkthrough that progressively builds an active-active PostgreSQL deployment, available as documentation, an interactive terminal guide, and a one-click GitHub Codespaces environment (#48)
- Added the ability to configure the database name, owner, and admin role via Helm values (`initdb.database`, `initdb.owner`, `pgEdge.adminUser`). Also added documentation covering all managed users, their authentication methods, and how to create additional users or disable passwords (#54)

### Changed

- Rewrote the quickstart documentation for experienced Kubernetes users with a streamlined, copy-paste-and-go guide that assumes a working cluster (#46)
- Updated default Postgres image to 18, CloudNativePG to 1.29, and cert-manager to use the latest release (#51)
- Rewrote the init-spock job from Python to Go with a declarative resource engine that inspects actual state and converges toward desired state. Includes parallel execution within dependency phases and reduces the Docker image from ~150MB to ~15MB (#50)

### Fixed

- Fixed init-spock admin connection pool to honor internalHostname for cluster-local routing, matching the existing health check behavior